### PR TITLE
Scan periscope gradient data for large changes and send email

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 entry_points = {
     "console_scripts": [
         "ska_trend_wrong_box_updates=ska_trend.wrong_box_anom.wrong_box_anom:main",
+        "ska_trend_bad_periscope=ska_trend.bad_periscope_gradient.periscope_update:main",
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ setup(
         " Smithsonian Astrophysical Observatory\nAll rights reserved."
     ),
     entry_points=entry_points,
-    packages=["ska_trend", "ska_trend.wrong_box_anom", "ska_trend.bad_periscope_gradient"],
+    packages=[
+        "ska_trend",
+        "ska_trend.wrong_box_anom",
+        "ska_trend.bad_periscope_gradient",
+    ],
     package_data={
         "ska_trend": [
             "wrong_box_anom/index_template.html",

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,12 @@ setup(
         " Smithsonian Astrophysical Observatory\nAll rights reserved."
     ),
     entry_points=entry_points,
-    packages=["ska_trend", "ska_trend.wrong_box_anom"],
+    packages=["ska_trend", "ska_trend.wrong_box_anom", "ska_trend.bad_periscope_gradient"],
     package_data={
         "ska_trend": [
             "wrong_box_anom/index_template.html",
             "wrong_box_anom/task_schedule.cfg",
+            "bad_periscope_gradient/task_schedule.cfg",
         ]
     },
 )

--- a/ska_trend/bad_periscope_gradient/periscope_update.py
+++ b/ska_trend/bad_periscope_gradient/periscope_update.py
@@ -122,6 +122,7 @@ def main(sys_args=None):
         hiccups = Table.read(data_file)
         start = hiccups["time"].max()
 
+    logger.info("Checking for bad data starting at {}".format(start))
     bads = check_for_bad_times(start)
 
     if len(bads) > 0:
@@ -133,6 +134,7 @@ def main(sys_args=None):
             & (bads["manvr_obsid"] < 38000)
         )
         if np.any(bad_science):
+            logger.info(f"Sending email alert for {len(bads[bad_science])} obsids")
             send_process_email(opt, bads[bad_science])
 
         # Append the new bad data to the existing data file
@@ -141,6 +143,7 @@ def main(sys_args=None):
         else:
             hiccups = bads
         hiccups.sort("time")
+        logger.info("Writing data to {}".format(data_file))
         hiccups.write(data_file, format="ascii.ecsv", overwrite=True)
 
 

--- a/ska_trend/bad_periscope_gradient/periscope_update.py
+++ b/ska_trend/bad_periscope_gradient/periscope_update.py
@@ -1,0 +1,144 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Check for bad data and discontinuities in periscope gradients"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from acdc.common import send_mail
+from astropy.table import Table, vstack
+from cheta import fetch
+from cxotime import CxoTime
+from kadi import events
+from ska_helpers.logging import basic_logger
+
+from ska_trend import __version__
+
+logger = basic_logger(__name__, level="INFO")
+
+
+def get_opt():
+    parser = argparse.ArgumentParser(
+        description="Periscope gradient checker {}".format(__version__)
+    )
+    parser.add_argument(
+        "--email",
+        type=str,
+        default=[],
+        action="append",
+        dest="emails",
+        help="Email address to send alerts",
+    )
+    parser.add_argument("--out-dir", type=str, default=".", help="Out directory")
+    return parser
+
+
+def check_for_bad_times(start):
+    """
+    Review perigee gradient data for discontinuities and bad data.
+
+    This uses 0.0032 K as the quantization and checks that the difference between
+    consecutive samples are not more than 5 * quantization.  Times with samples
+    that exceed this threshold are put into a table along with the telemetered
+    COBSRQID, AOACASEQ, and AOPCADMD.  The obsid of the most recent maneuver is
+    also captured, as it looks like for science processing the problem can be that
+    the gradient data for the science interval extends into the time of an anomaly,
+    even though AOACASEQ and AOPCADMD show that the spacecraft is in anomaly state,
+    and COBSRQID is often 0.
+
+    Parameters
+    ----------
+    start : str
+        Start time for search
+
+    Returns
+    -------
+    bad_events : astropy.table.Table
+        Table of bad events
+    """
+    msids = ["OOBAGRD3", "OOBAGRD6"]
+    quantization = 0.0032
+    sampling = 32.80000185966492
+    quant_mult = 5
+
+    bad_events = []
+    for msid in msids:
+        dat = fetch.Msid(msid, start, filter_bad=True)
+        dat.interpolate(dt=sampling)
+        diff = np.diff(dat.vals)
+        nok = np.abs(diff) > quantization * quant_mult
+
+        for hit in np.where(nok)[0]:
+            event = {
+                "time": dat.times[hit],
+                "date": CxoTime(dat.times[hit]).date,
+                "msid": msid,
+            }
+            local_manvrs = events.manvrs.filter(
+                start=dat.times[hit] - (7 * 86400), stop=dat.times[hit] + (1 * 86400)
+            )
+            extra_msids = ["COBSRQID", "AOPCADMD", "AOACASEQ"]
+            extra_defaults = {"COBSRQID": 0, "AOPCADMD": "N/A", "AOACASEQ": "N/A"}
+            for extra_msid in extra_msids:
+                mdat = fetch.Msid(extra_msid, dat.times[hit] - 200, dat.times[hit] + 50)
+                # get last sample before hit
+                hit_idx = np.searchsorted(mdat.times, dat.times[hit])
+                if hit_idx == 0:
+                    event.update({extra_msid: extra_defaults[extra_msid]})
+                else:
+                    event.update({extra_msid: mdat.vals[hit_idx - 1]})
+            last_manvr = None
+            for manvr in local_manvrs:
+                if manvr.tstart < dat.times[hit]:
+                    last_manvr = manvr
+            event.update({"manvr_obsid": last_manvr.obsid})
+            event.update({"manvr_tstart": last_manvr.tstart})
+            event.update({"manvr_tstop": last_manvr.tstop})
+            bad_events.append(event.copy())
+    return Table(bad_events)
+
+
+def send_process_email(opt, bad_science_data):
+    subject = "perigee gradient data: bad data or discontinuities found"
+    lines = [
+        "Discontinuities found in perigee gradient data.",
+        "Check V&V for these science observations.",
+    ]
+    lines.extend(bad_science_data.pformat(max_lines=-1, max_width=-1))
+    text = "\n".join(lines)
+    logger.info(text)
+    send_mail(logger, opt, subject, text, __file__)
+
+
+def main(sys_args=None):
+    opt = get_opt().parse_args(sys_args)
+
+    data_file = Path(opt.out_dir) / "data.ecsv"
+
+    start = "2001:001"
+    hiccups = None
+    if data_file.exists():
+        hiccups = Table.read(data_file)
+        start = hiccups["time"].max()
+
+    bads = check_for_bad_times(start)
+
+    if len(bads) > 0:
+        bad_science = (
+            (bads["manvr_obsid"] != -999)
+            & (bads["manvr_obsid"] != 0)
+            & (bads["manvr_obsid"] < 38000)
+        )
+        if np.any(bad_science):
+            send_process_email(opt, bads[bad_science])
+
+        if hiccups is not None:
+            hiccups = vstack([hiccups, bads])
+        else:
+            hiccups = bads
+        hiccups.sort("time")
+        hiccups.write(data_file, format="ascii.ecsv", overwrite=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/ska_trend/bad_periscope_gradient/periscope_update.py
+++ b/ska_trend/bad_periscope_gradient/periscope_update.py
@@ -113,6 +113,7 @@ def send_process_email(opt, bad_science_data):
 def main(sys_args=None):
     opt = get_opt().parse_args(sys_args)
 
+    Path(opt.outdir).mkdir(parents=True, exist_ok=True)
     data_file = Path(opt.out_dir) / "data.ecsv"
 
     start = "2001:001"
@@ -124,6 +125,8 @@ def main(sys_args=None):
     bads = check_for_bad_times(start)
 
     if len(bads) > 0:
+        # If the obsid associated with the last maneuver before an event
+        # was a science obsid then send an email alert.
         bad_science = (
             (bads["manvr_obsid"] != -999)
             & (bads["manvr_obsid"] != 0)
@@ -132,6 +135,7 @@ def main(sys_args=None):
         if np.any(bad_science):
             send_process_email(opt, bads[bad_science])
 
+        # Append the new bad data to the existing data file
         if hiccups is not None:
             hiccups = vstack([hiccups, bads])
         else:

--- a/ska_trend/bad_periscope_gradient/periscope_update.py
+++ b/ska_trend/bad_periscope_gradient/periscope_update.py
@@ -35,7 +35,7 @@ def get_opt():
 
 def check_for_bad_times(start):
     """
-    Review perigee gradient data for discontinuities and bad data.
+    Review periscope gradient data for discontinuities and bad data.
 
     This uses 0.0032 K as the quantization and checks that the difference between
     consecutive samples are not more than 5 * quantization.  Times with samples
@@ -99,12 +99,13 @@ def check_for_bad_times(start):
 
 
 def send_process_email(opt, bad_science_data):
-    subject = "perigee gradient data: bad data or discontinuities found"
+    subject = "periscope gradient data: bad data or discontinuities found"
     lines = [
-        "Discontinuities found in perigee gradient data.",
+        "Discontinuities found in periscope gradient data.",
         "Check V&V for these science observations.",
     ]
-    lines.extend(bad_science_data.pformat(max_lines=-1, max_width=-1))
+    cols = ['date', 'manvr_obsid', 'msid', 'AOPCADMD', 'AOACASEQ', 'COBSRQID']
+    lines.extend(bad_science_data[cols].pformat(max_lines=-1, max_width=-1))
     text = "\n".join(lines)
     logger.info(text)
     send_mail(logger, opt, subject, text, __file__)
@@ -126,6 +127,8 @@ def main(sys_args=None):
     bads = check_for_bad_times(start)
 
     if len(bads) > 0:
+        bads.sort('time')
+
         # If the obsid associated with the last maneuver before an event
         # was a science obsid then send an email alert.
         bad_science = (

--- a/ska_trend/bad_periscope_gradient/periscope_update.py
+++ b/ska_trend/bad_periscope_gradient/periscope_update.py
@@ -113,7 +113,7 @@ def send_process_email(opt, bad_science_data):
 def main(sys_args=None):
     opt = get_opt().parse_args(sys_args)
 
-    Path(opt.outdir).mkdir(parents=True, exist_ok=True)
+    Path(opt.out_dir).mkdir(parents=True, exist_ok=True)
     data_file = Path(opt.out_dir) / "data.ecsv"
 
     start = "2001:001"

--- a/ska_trend/bad_periscope_gradient/task_schedule.cfg
+++ b/ska_trend/bad_periscope_gradient/task_schedule.cfg
@@ -1,0 +1,56 @@
+# Configuration file for task_schedule.pl
+
+subject           Bad Periscope Data
+timeout           2400               # Default tool timeout
+heartbeat_timeout 30000             # Maximum age of heartbeat file (seconds)
+iterations        1                 # Run once then shut down task_schedule
+print_error       1                 # Print full log of errors
+disable_alerts    0                 # Don't disable alerts since this jobs runs just once/day
+loud              0                 # Run loudly or quietly (production mode)
+
+# Data files and directories.  The *_dir vars can have $ENV{} vars which
+# get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
+
+data_dir     $ENV{SKA_DATA}/bad_periscope_gradient      # Data file directory
+log_dir      $ENV{SKA_DATA}/bad_periscope_gradient/logs  # Log file directory
+bin_dir      $ENV{SKA_SHARE}/bad_periscope_gradient     # Bin dir (optional, see task def'n)
+master_log   master.log             # Composite master log (created in log_dir)
+
+# Email addresses that receive an alert if there was a severe error in
+# running jobs (i.e. couldn't start jobs or couldn't open log file).
+# Processing errors *within* the jobs are caught with watch_cron_logs
+
+alert       aca@cfa.harvard.edu
+#alert        jeanconn@head.cfa.harvard.edu
+#notify	    jeanconn@head.cfa.harvard.edu
+
+# Define task parameters
+#  cron: Job repetition specification ala crontab
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
+#        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#  log: Name of log.  Can have $ENV{} vars which get interpolated.
+#        If log is set to '' then no log file will be created
+#        If log is not defined it is set to <task_name>.log.
+#        If log_dir is defined then log_dir is prepended to non-absolute log names.
+#  timeout: Maximum time (seconds) for job before timing out
+
+# This has multiple jobs which get run in specified order
+# Note the syntax 'exec <number> : cmd', which means that the given command is
+# executed only once for each <number> of times the task is executed.  In the
+# example below, the commands are done once each 1, 2, and 4 minutes, respectively.
+
+<task bad_periscope_gradient>
+      cron       * * * * *
+      check_cron * * * * *
+      exec 1: ska_trend_bad_periscope --out-dir $ENV{SKA}/data/bad_periscope_gradient
+      <check>
+        <error>
+          #    File           Expression
+          #  ----------      ---------------------------
+             *     Use of uninitialized value
+             *     error
+             *     warning
+             *     fatal
+        </error>
+      </check>
+</task>

--- a/ska_trend/bad_periscope_gradient/task_schedule.cfg
+++ b/ska_trend/bad_periscope_gradient/task_schedule.cfg
@@ -42,7 +42,7 @@ alert       aca@cfa.harvard.edu
 <task bad_periscope_gradient>
       cron       * * * * *
       check_cron * * * * *
-      exec 1: ska_trend_bad_periscope --out-dir $ENV{SKA}/data/bad_periscope_gradient
+      exec 1: ska_trend_bad_periscope --out-dir $ENV{SKA}/data/bad_periscope_gradient --email=aca\@cfa.harvard.edu
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
## Description

Scan periscope gradient data for large changes and send email

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I ran this with no data file, and confirmed it sends an email with the list of instances.  I then removed the last instance that started with a dwell with a science observation and it sends an email that includes obsid 27506.
```
Discontinuities found in periscope gradient data.
Check V&V for these science observations.
date | msid | AOPCADMD | AOACASEQ | COBSRQID | manvr_obsid
2022:293:16:26:47.422 | OOBAGRD6 | NPNT | KALM | 27506.0 | 27506
2022:293:16:27:20.222 | OOBAGRD6 | NPNT | KALM | 27506.0 | 27506
2022:295:16:47:24.231 | OOBAGRD6 | STBY | AQXN | 0.0 | 27506
2022:295:16:47:57.031 | OOBAGRD3 | STBY | AQXN | 0.0 | 27506
2022:295:17:21:50.632 | OOBAGRD6 | STBY | BRIT | 0.0 | 27506
2022:295:17:21:50.632 | OOBAGRD3 | STBY | BRIT | 0.0 | 27506
2022:295:17:22:23.432 | OOBAGRD3 | STBY | BRIT | 0.0 | 27506
2022:295:17:22:23.432 | OOBAGRD6 | STBY | BRIT | 0.0 | 27506
2022:295:17:43:42.632 | OOBAGRD3 | NSUN | AQXN | 0.0 | 27506
```

