### PR TITLE
Fid drop monitor and report

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ entry_points = {
         "ska_trend_wrong_box_updates=ska_trend.wrong_box_anom.wrong_box_anom:main",
         "ska_trend_bad_periscope=ska_trend.bad_periscope_gradient.periscope_update:main",
         "ska_trend_centroid_dashboard=ska_trend.centroid_dashboard.app:main",
+        "ska_trend_fid_drop_mon_update=ska_trend.fid_drop_mon.update:main",
     ]
 }
 
@@ -28,6 +29,7 @@ setup(
         "ska_trend.wrong_box_anom",
         "ska_trend.bad_periscope_gradient",
         "ska_trend.centroid_dashboard",
+        "ska_trend.fid_drop_mon",
     ],
     package_data={
         "ska_trend": [
@@ -36,6 +38,8 @@ setup(
             "bad_periscope_gradient/task_schedule.cfg",
             "centroid_dashboard/index_template.html",
             "centroid_dashboard/task_schedule.cfg",
+            "fid_drop_mon/index_template.html",
+            "fid_drop_mon/task_schedule.cfg",
         ]
     },
 )

--- a/ska_trend/fid_drop_mon/index_template.html
+++ b/ska_trend/fid_drop_mon/index_template.html
@@ -61,7 +61,15 @@
 
 <H4>Fid drops in last year</H4>
 <table class="table table-striped table-bordered table-hover">
-<TR><TH>Interval Start</TH><TH>Interval Stop</TH></TD><TH>Obsid</TH><TH>Fid Slot</TH><TH>Track Fraction</TH><TH>Notes</TH></TR>
+<TR>
+    <TH class="text-center" style="width: 15%;">Interval Start</TH>
+    <TH class="text-center" style="width: 15%;">Interval Stop</TH>
+    <TH class="text-center" style="width: 10%;">Obsid</TH>
+    <TH class="text-center" style="width: 10%;">Fid Slot</TH>
+    <TH class="text-center" style="width: 10%;">Track Fraction</TH>
+    <TH class="text-center" style="width: 40%;">Notes</TH>
+</TR>
+
 {% for obs in obs_events_last %}
 <TR>
 <TD>{{obs['start']}}</TD>
@@ -77,7 +85,14 @@
 
 <H4>Fid drop events starting from {{start}}</H4>
 <table class="table table-striped table-bordered table-hover">
-<TR><TH>Interval Start</TH><TH>Interval Stop</TH><TH>Obsid</TH><TH>Fid Slot</TH><TH>Track Fraction</TH><TH>Notes</TH></TR>
+<TR>
+    <TH class="text-center" style="width: 15%;">Interval Start</TH>
+    <TH class="text-center" style="width: 15%;">Interval Stop</TH>
+    <TH class="text-center" style="width: 10%;">Obsid</TH>
+    <TH class="text-center" style="width: 10%;">Fid Slot</TH>
+    <TH class="text-center" style="width: 10%;">Track Fraction</TH>
+    <TH class="text-center" style="width: 40%;">Notes</TH>
+</TR>
 {% for obs in obs_events %}
 <TR>
 <TD>{{obs['start']}}</TD>

--- a/ska_trend/fid_drop_mon/index_template.html
+++ b/ska_trend/fid_drop_mon/index_template.html
@@ -1,0 +1,100 @@
+<HTML>
+    <HEADER>
+        <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+                <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+                rel="stylesheet"
+                integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+                crossorigin="anonymous">
+
+                <style>
+                    h1 {
+                        color: #990000;
+                    }
+
+                    h2 {
+                        color: #990000;
+                    }
+                    .content-container {
+                    margin-left: 5px; /* Adjust the value as needed */
+                    å}
+
+                </style>
+      <title>Fid Light Drops</title>
+
+    </HEADER>
+    <BODY>
+
+            <!--#include virtual="/incl/header.html"-->
+<div class="container-md content-container">
+<H3>Fid Light Drops</H3>
+
+<div class="accordion" id="accordionExample">
+    <div class="accordion-item">
+        <h4 class="accordion-header" id="heading-table">
+            <button class="accordion-button collapsed bg-primary bg-opacity-25" type="button" data-bs-toggle="collapse"
+                data-bs-target="#info-table" aria-expanded="true" aria-controls="info-table">
+                Table Information
+            </button>
+        </h4>
+        <div id="info-table" class="accordion-collapse collapse" aria-labelledby="info-table"
+            data-bs-parent="#accordionExample">
+            <div class="accordion-body bg-primary bg-opacity-10">
+                The table below is of fid drop events.
+                <UL>
+                    <LI>Interval Start : start of tracking interval - usually the start of Kalman for the obsid dwell,
+                        but if there is a NMAN transition in an interval this can be a later NPNT transition at the same pointing. </LI>
+                    <LI>Interval Stop : end of tracking interval - usually transition to NMAN</LI>
+                    <LI>Obsid : Obsid assigned to the maneuver event to this dwell by kadi events</LI>
+                    <LI>Fid Slot : Fid slot number</LI>
+                    <LI>Track Fraction : Fraction of the interval that the fid light was tracked (AOACFCTN == "TRAK")</LI>
+                    <LI>Notes : Any notes from the google sheet</LI>
+                </UL>
+
+                The notes are from the google sheet at <a href="{{sheet_url}}">{{sheet_url}}</a>.
+            </div>
+        </div>
+    </div>
+</div>
+
+<H4>Fid drops in last year</H4>
+<table class="table table-striped table-bordered table-hover">
+<TR><TH>Interval Start</TH><TH>Interval Stop</TH></TD><TH>Obsid</TH><TH>Fid Slot</TH><TH>Track Fraction</TH><TH>Notes</TH></TR>
+{% for obs in obs_events_last %}
+<TR>
+<TD>{{obs['start']}}</TD>
+<TD>{{obs['stop']}}</TD>
+<TD ALIGN="right">{{obs['obsid_telem']}}</TD>
+<TD ALIGN="right">{{ obs['slot'] }}</TD>
+<TD ALIGN="right">{{ '%.2f' | format(obs['track_fraction'])}}</TD>
+<TD ALIGN="right">{{ obs['notes'] }}</TD>
+</TR>
+{% endfor %}
+</TABLE>
+
+
+<H4>Fid drop events starting from {{start}}</H4>
+<table class="table table-striped table-bordered table-hover">
+<TR><TH>Interval Start</TH><TH>Interval Stop</TH><TH>Obsid</TH><TH>Fid Slot</TH><TH>Track Fraction</TH><TH>Notes</TH></TR>
+{% for obs in obs_events %}
+<TR>
+<TD>{{obs['start']}}</TD>
+<TD>{{obs['stop']}}</TD>
+<TD ALIGN="right">{{obs['obsid_telem']}}</A></TD>
+<TD ALIGN="right">{{ obs['slot'] }}</TD>
+<TD ALIGN="right">{{ '%.2f' | format(obs['track_fraction'])}}</TD>
+<TD ALIGN="right">{{ obs['notes'] }}</TD>
+</TR>
+{% endfor %}
+</TABLE>
+</div>
+
+<script
+src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+crossorigin="anonymous">
+</script>
+</BODY>
+</HTML>

--- a/ska_trend/fid_drop_mon/index_template.html
+++ b/ska_trend/fid_drop_mon/index_template.html
@@ -64,17 +64,19 @@
 <TR>
     <TH class="text-center" style="width: 15%;">Interval Start</TH>
     <TH class="text-center" style="width: 15%;">Interval Stop</TH>
+    <TH class="text-center" style="width: 10%;">Load Name</TH>
     <TH class="text-center" style="width: 10%;">Obsid</TH>
     <TH class="text-center" style="width: 10%;">Fid Slot</TH>
     <TH class="text-center" style="width: 10%;">Track Fraction</TH>
-    <TH class="text-center" style="width: 40%;">Notes</TH>
+    <TH class="text-center" style="width: 30%;">Notes</TH>
 </TR>
 
 {% for obs in obs_events_last %}
 <TR>
 <TD>{{obs['start']}}</TD>
 <TD>{{obs['stop']}}</TD>
-<TD ALIGN="right">{{obs['obsid_telem']}}</TD>
+<TD>{{obs['load_name']}}</TD>
+<TD ALIGN="right">{{obs['obsid']}}</TD>
 <TD ALIGN="right">{{ obs['slot'] }}</TD>
 <TD ALIGN="right">{{ '%.2f' | format(obs['track_fraction'])}}</TD>
 <TD ALIGN="right">{{ obs['notes'] }}</TD>
@@ -88,16 +90,20 @@
 <TR>
     <TH class="text-center" style="width: 15%;">Interval Start</TH>
     <TH class="text-center" style="width: 15%;">Interval Stop</TH>
+    <TH class="text-center" style="width: 10%;">Load Name</TH>
     <TH class="text-center" style="width: 10%;">Obsid</TH>
     <TH class="text-center" style="width: 10%;">Fid Slot</TH>
     <TH class="text-center" style="width: 10%;">Track Fraction</TH>
-    <TH class="text-center" style="width: 40%;">Notes</TH>
+    <TH class="text-center" style="width: 30%;">Notes</TH>
 </TR>
 {% for obs in obs_events %}
 <TR>
 <TD>{{obs['start']}}</TD>
 <TD>{{obs['stop']}}</TD>
-<TD ALIGN="right">{{obs['obsid_telem']}}</A></TD>
+<TD ALIGN="center">{{obs['load_name']}}</TD>
+<TD ALIGN="right">
+<A HREF="https://kadi.cfa.harvard.edu/mica/?obsid_or_date={{obs['obsid']}}&load_name={{obs['load_name']}}">
+    {{obs['obsid']}}</A></TD>
 <TD ALIGN="right">{{ obs['slot'] }}</TD>
 <TD ALIGN="right">{{ '%.2f' | format(obs['track_fraction'])}}</TD>
 <TD ALIGN="right">{{ obs['notes'] }}</TD>

--- a/ska_trend/fid_drop_mon/index_template.html
+++ b/ska_trend/fid_drop_mon/index_template.html
@@ -75,7 +75,7 @@
 <TR>
 <TD>{{obs['start']}}</TD>
 <TD>{{obs['stop']}}</TD>
-<TD>{{obs['load_name']}}</TD>
+<TD align="center">{{obs['load_name']}}</TD>
 <TD ALIGN="right">
     <A HREF="https://kadi.cfa.harvard.edu/mica/?obsid_or_date={{obs['obsid']}}&load_name={{obs['load_name']}}">
         {{obs['obsid']}}</A></TD>

--- a/ska_trend/fid_drop_mon/index_template.html
+++ b/ska_trend/fid_drop_mon/index_template.html
@@ -19,7 +19,7 @@
                     }
                     .content-container {
                     margin-left: 5px; /* Adjust the value as needed */
-                    å}
+                    }
 
                 </style>
       <title>Fid Light Drops</title>

--- a/ska_trend/fid_drop_mon/index_template.html
+++ b/ska_trend/fid_drop_mon/index_template.html
@@ -76,7 +76,9 @@
 <TD>{{obs['start']}}</TD>
 <TD>{{obs['stop']}}</TD>
 <TD>{{obs['load_name']}}</TD>
-<TD ALIGN="right">{{obs['obsid']}}</TD>
+<TD ALIGN="right">
+    <A HREF="https://kadi.cfa.harvard.edu/mica/?obsid_or_date={{obs['obsid']}}&load_name={{obs['load_name']}}">
+        {{obs['obsid']}}</A></TD>
 <TD ALIGN="right">{{ obs['slot'] }}</TD>
 <TD ALIGN="right">{{ '%.2f' | format(obs['track_fraction'])}}</TD>
 <TD ALIGN="right">{{ obs['notes'] }}</TD>

--- a/ska_trend/fid_drop_mon/task_schedule.cfg
+++ b/ska_trend/fid_drop_mon/task_schedule.cfg
@@ -1,0 +1,56 @@
+# Configuration file for task_schedule.pl to run astromon jobs
+
+subject           Fid Drop Monitor
+timeout           2400               # Default tool timeout
+heartbeat_timeout 30000             # Maximum age of heartbeat file (seconds)
+iterations        1                 # Run once then shut down task_schedule
+print_error       1                 # Print full log of errors
+disable_alerts    0                 # Don't disable alerts since this jobs runs just once/day
+loud              0                 # Run loudly or quietly (production mode)
+
+# Data files and directories.  The *_dir vars can have $ENV{} vars which
+# get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
+
+data_dir     $ENV{SKA_DATA}/fid_drop_mon      # Data file directory
+log_dir      $ENV{SKA_DATA}/fid_drop_mon/logs  # Log file directory
+bin_dir      $ENV{SKA_SHARE}/fid_drop_mon     # Bin dir (optional, see task def'n)
+master_log   master.log             # Composite master log (created in log_dir)
+
+# Email addresses that receive an alert if there was a severe error in
+# running jobs (i.e. couldn't start jobs or couldn't open log file).
+# Processing errors *within* the jobs are caught with watch_cron_logs
+
+alert       aca@cfa.harvard.edu
+#alert        jeanconn@head.cfa.harvard.edu
+#notify	    jeanconn@head.cfa.harvard.edu
+
+# Define task parameters
+#  cron: Job repetition specification ala crontab
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
+#        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#  log: Name of log.  Can have $ENV{} vars which get interpolated.
+#        If log is set to '' then no log file will be created
+#        If log is not defined it is set to <task_name>.log.
+#        If log_dir is defined then log_dir is prepended to non-absolute log names.
+#  timeout: Maximum time (seconds) for job before timing out
+
+# This has multiple jobs which get run in specified order
+# Note the syntax 'exec <number> : cmd', which means that the given command is
+# executed only once for each <number> of times the task is executed.  In the
+# example below, the commands are done once each 1, 2, and 4 minutes, respectively.
+
+<task fid_drop_mon>
+      cron       * * * * *
+      check_cron * * * * *
+      exec 1: ska_trend_fid_drop_mon_update --out-dir $ENV{SKA}/www/ASPECT/fid_drop_mon
+      <check>
+        <error>
+          #    File           Expression
+          #  ----------      ---------------------------
+             *     Use of uninitialized value
+             *     error
+             *     warning
+             *     fatal
+        </error>
+      </check>
+</task>

--- a/ska_trend/fid_drop_mon/task_schedule.cfg
+++ b/ska_trend/fid_drop_mon/task_schedule.cfg
@@ -11,9 +11,8 @@ loud              0                 # Run loudly or quietly (production mode)
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}/fid_drop_mon      # Data file directory
-log_dir      $ENV{SKA_DATA}/fid_drop_mon/logs  # Log file directory
-bin_dir      $ENV{SKA_SHARE}/fid_drop_mon     # Bin dir (optional, see task def'n)
+data_dir     $ENV{SKA}/data/fid_drop_mon      # Data file directory
+log_dir      $ENV{SKA}/data/fid_drop_mon/logs  # Log file directory
 master_log   master.log             # Composite master log (created in log_dir)
 
 # Email addresses that receive an alert if there was a severe error in

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -21,7 +21,7 @@ DOC_ID = "1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw"
 GID = "1266351479"
 url_start = "https://docs.google.com/spreadsheets/d"
 GSHEET_URL = f"{url_start}/{DOC_ID}/export?format=csv&id={DOC_ID}&gid={GID}"
-GSHEET_USER_URL = f"{url_start}/{DOC_ID}/edit?usp=sharing"
+GSHEET_USER_URL = f"{url_start}/{DOC_ID}/edit?gid={GID}#gid={GID}"
 
 # Constants and file path definitions
 FILE_DIR = Path(__file__).parent

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -17,8 +17,8 @@ from ska_helpers.run_info import log_run_info
 
 from ska_trend import __version__
 
-DOC_ID = "1qHF6-3oz6MSJYd3goQTMdcteXWUjKyHycdWSMCd9S40"
-GID = 0
+DOC_ID = "1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw"
+GID = "1266351479"
 url_start = "https://docs.google.com/spreadsheets/d"
 GSHEET_URL = f"{url_start}/{DOC_ID}/export?format=csv&id={DOC_ID}&gid={GID}"
 GSHEET_USER_URL = f"{url_start}/{DOC_ID}/edit?usp=sharing"

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -370,11 +370,12 @@ def main(args=None):
                 send_mail(
                     LOGGER,
                     opt,
-                    f"Fid drop: Obsid {row['obsid_telem']} {row['start']}",
+                    f"Fid drop: Obsid {row['obsid']} {row['start']}",
                     f"Fid drop in the dwell that starts at {row['start']}\n"
-                    f"Obsid {row['obsid_telem']} Fid slot {row['slot']} tracked "
+                    f"Obsid {row['obsid']} Fid slot {row['slot']} tracked "
                     f"for {row['track_fraction']:.3f} fraction.\n"
-                    f"See {URL}",
+                    f"See {URL}\n"
+                    f"Review with aca_view --start '{row['start']}' --stop '{row['stop']}'\n",
                     __file__,
                 )
 

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -75,11 +75,13 @@ def get_vehicle_only_intervals(
     Parameters
     ----------
     start : CxoTimeLike
-        Start time for intervals, where ``start`` must be before
-        (or equal to) the start time of the SCS-107 run.
+        Start time filter for intervals, where ``start`` must be before
+        (or equal to) the start time of the SCS-107 run. If ``None``, the
+        start time is set to the SOSA patch start time (2011:335).
     stop : CxoTimeLike
         Stop time for intervals, where ``stop`` must be after
-        the start time of the SCS-107 run.
+        the start time of the SCS-107 run. If ``None``, the stop time is set
+        to the current time.
 
     Returns
     -------
@@ -91,13 +93,8 @@ def get_vehicle_only_intervals(
         - datestop: Stop time of the interval (time of first observing command).
     """
     sosa_patch = CxoTime("2011:335")
-    stop = CxoTime(stop) if stop is not None else CxoTime()
-    start = sosa_patch if start is None else CxoTime(start)
-
-    if start < sosa_patch:
-        raise ValueError(
-            f"Start time {start} must be after SOSA patch start time {sosa_patch}"
-        )
+    stop = CxoTime(stop) if stop is not None else CxoTime.now()
+    start = sosa_patch if start is None else np.max([CxoTime(start), sosa_patch])
 
     cmds = kc.get_cmds(start=start)
     ok = (cmds["tlmsid"] == "OORMPDS") & (cmds["source"] == "CMD_EVT")

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -301,7 +301,7 @@ def main(args=None):
     fid_data_archive = None
     min_table_start = "2011:335"
 
-    if Path(fid_data_file).exists():
+    if fid_data_file.exists():
         fid_data_archive = Table.read(fid_data_file, format="ascii.ecsv")
         start = CxoTime(fid_data_archive["start"][-1]) + 10 * u.s
     else:

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -79,7 +79,7 @@ def get_vehicle_only_intervals(
         (or equal to) the start time of the SCS-107 run. If ``None``, the
         start time is set to the SOSA patch start time (2011:335).
     stop : CxoTimeLike
-        Stop time for intervals, where ``stop`` must be after
+        Stop time filter for intervals, where ``stop`` must be after
         the start time of the SCS-107 run. If ``None``, the stop time is set
         to the current time.
 
@@ -97,6 +97,8 @@ def get_vehicle_only_intervals(
     start = sosa_patch if start is None else np.max([CxoTime(start), sosa_patch])
 
     cmds = kc.get_cmds(start=start)
+    # This filters on tlmsid and source first because that's fast.
+    # Then those cmds are filtered by the SCS-107 event type.
     ok = (cmds["tlmsid"] == "OORMPDS") & (cmds["source"] == "CMD_EVT")
     cmds_rmpds_evt = cmds[ok]
     ok2 = cmds_rmpds_evt["event"] == "SCS-107"

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -1,0 +1,376 @@
+import argparse
+import functools
+from pathlib import Path
+
+import astropy.units as u
+import jinja2
+import numpy as np
+from acdc.common import send_mail
+from astropy.table import Table, join, vstack
+from cheta import fetch
+from cheta.utils import logical_intervals
+from cxotime import CxoTime, CxoTimeLike
+from kadi import events
+from kadi.commands.observations import get_starcats
+from ska_helpers.logging import basic_logger
+from ska_helpers.run_info import log_run_info
+
+from ska_trend import __version__
+
+DOC_ID = "1qHF6-3oz6MSJYd3goQTMdcteXWUjKyHycdWSMCd9S40"
+GID = 0
+url_start = "https://docs.google.com/spreadsheets/d"
+GSHEET_URL = f"{url_start}/{DOC_ID}/export?format=csv&id={DOC_ID}&gid={GID}"
+GSHEET_USER_URL = f"{url_start}/{DOC_ID}/edit?usp=sharing"
+
+# Constants and file path definitions
+FILE_DIR = Path(__file__).parent
+
+
+def INDEX_TEMPLATE_PATH():
+    return FILE_DIR / "index_template.html"
+
+
+URL = "https://cxc.cfa.harvard.edu/mta/ASPECT/fid_drop_mon/index.html"
+LOGGER = basic_logger(__name__, level="INFO")
+
+fetch.data_source.set("cxc")
+
+
+def get_opt():
+    parser = argparse.ArgumentParser(description="Fid drop monitor")
+    parser.add_argument("--start", help="Start date")
+    parser.add_argument("--stop", help="Stop date")
+    parser.add_argument(
+        "--out-dir",
+        default="./out",
+        help="Output directory",
+    )
+    parser.add_argument(
+        "--email",
+        action="append",
+        dest="emails",
+        default=[],
+        help="Email address for notificaion",
+    )
+    return parser
+
+
+def get_scs107_intervals(start: CxoTimeLike, stop: CxoTimeLike) -> Table:
+    """
+    Get the SCS107 SOSA intervals from the telemetry.
+
+    This is only valid after SOSA start in 2011.
+
+    Parameters
+    ----------
+    start : CxoTimeLike
+        Start time for the data to be fetched.
+    stop : CxoTimeLike
+        Stop time for the data to be fetched.
+
+    Returns
+    -------
+    Table
+        Table of SCS107 SOSA intervals.
+
+    The returned table has the following columns:
+        - datestart: Start time of the interval.
+        - datestop: Stop time of the interval.
+    """
+    import kadi.commands as kc
+
+    # Manually add some SCS107s before cmd event sheet
+    scs107_dates = [
+        "2017:254:07:51:39.000",
+        "2017:250:02:41:28.000",
+        "2015:173:22:40:00.000",
+        "2015:076:04:34:30.000",
+        "2014:357:11:32:23.000",
+        "2014:356:04:52:35.000",
+        "2014:255:11:51:18.000",
+        "2014:007:20:39:16.000",
+        "2013:076:12:30:11.336",
+        "2012:201:11:44:57.000",
+        "2012:196:21:07:00.000",
+        "2012:194:19:59:42.088",
+        "2012:138:02:18:00.000",
+        "2012:073:22:41:25.000",
+        "2012:067:05:29:47.000",
+        "2012:058:03:24:21.000",
+        "2012:027:15:15:02.056",
+        "2012:023:06:00:38.000",
+    ]
+
+    sosa_patch = "2011:335"
+    min_cmd_start = np.min([CxoTime(start), CxoTime(sosa_patch)])
+    cmds = kc.get_cmds(start=min_cmd_start)
+    ok = (cmds["tlmsid"] == "OORMPDS") & (cmds["source"] == "CMD_EVT")
+    cmds_rmpds_evt = cmds[ok]
+    ok2 = cmds_rmpds_evt["event"] == "SCS-107"
+    cmd_dates_scs107 = [cmd["date"] for cmd in cmds_rmpds_evt[ok2]]
+    ok_sci_cmds = (cmds["source"] != "CMD_EVT") & (
+        np.in1d(cmds["scs"], [131, 132, 133])
+    )
+
+    scs107_dates.extend(cmd_dates_scs107)
+    scs107_dates = sorted(set(scs107_dates))
+
+    scs107_intervals = []
+
+    for date in scs107_dates:
+        # Get the date of the next command that has a source that isn't "CMD_EVT"
+        idx = np.searchsorted(cmds[ok_sci_cmds]["date"], date)
+        if idx == len(cmds[ok_sci_cmds]):
+            datestop = stop
+        else:
+            datestop = cmds[ok_sci_cmds]["date"][idx]
+        scs107_intervals.append(
+            {
+                "datestart": date,
+                "datestop": datestop,
+            }
+        )
+    return Table(scs107_intervals)
+
+
+def get_fid_data(start: CxoTimeLike, stop: CxoTimeLike) -> Table:
+    """
+    Get the fid tracking data for dwells from time start.
+
+    Parameters
+    ----------
+    start : CxoTimeLike
+        Start time for the data to be fetched.
+    stop : CxoTimeLike
+        Stop time for the data to be fetched.
+
+    Returns
+    -------
+    Table
+        Table of fid tracking data.
+
+    The returned table has the following columns:
+        - kalman_start: Start time of the Kalman filter.
+        - next_nman_start: Start time of the next NMAN.
+        - starcat_date: Date of the star catalog.
+        - obsid_starcat: Observation ID from star catalog / kadi starcat
+        - slot: Slot number.
+        - track_samples: Number of AOACFCT{n} samples.
+        - track_ok: Number of AOACFCT samples with "TRAK" status.
+        - track_fraction: Fraction of samples with "TRAK" status.
+    """
+    start = CxoTime(start)
+    stop = CxoTime(stop)
+    manvrs = events.manvrs.filter(
+        kalman_start__gte=start.date, next_nman_start__lte=stop.date
+    )
+    starcats = get_starcats(start=start - 5 * u.day)
+    dates = [starcat.date for starcat in starcats]
+
+    scs107_intervals = get_scs107_intervals(start, stop)
+
+    fid_data = []
+    for i, manvr in enumerate(manvrs):
+        LOGGER.info(
+            f"Processing npnt intervals in manvr with kalman_start: {manvr.kalman_start} "
+        )
+        # get the index of the starcat before the kalman start
+        idx = np.searchsorted(dates, manvr.kalman_start) - 1
+        # get the starcat before the kalman start
+        starcat = starcats[idx]
+        fid_slots = list(starcat["slot"][(starcat["type"] == "FID")])
+        fid_ids = list(starcat["id"][(starcat["type"] == "FID")])
+        if len(fid_slots) == 0:
+            continue
+        # If the "last" starcat happened before the last manvr kalman start
+        # skip, as something isn't right
+        if i > 0 and starcat.date < manvrs[i - 1].kalman_start:
+            continue
+
+        # Break up the manvr steady interval into NPNT intervals if needed
+        aopcadmd = fetch.Msid("AOPCADMD", manvr.kalman_start, manvr.next_nman_start)
+        npnt = logical_intervals(aopcadmd.times, aopcadmd.vals == "NPNT")
+
+        for row in npnt:
+            npnt_start = row["datestart"]
+            npnt_stop = row["datestop"]
+
+            # If the start of the interval is within an SCS107 interval, skip this row
+            if np.any(
+                (CxoTime(npnt_start) >= CxoTime(scs107_intervals["datestart"]))
+                & (CxoTime(npnt_start) <= CxoTime(scs107_intervals["datestop"]))
+            ):
+                continue
+
+            # Check CORADMEN for SCS107 equivalent
+            radmon = fetch.Msid("CORADMEN", npnt_start, npnt_stop)
+            # If SCS107, truncate the range to process
+            if np.any(radmon.vals == "DISA"):
+                npnt_stop = CxoTime(
+                    radmon.times[np.where(radmon.vals == "DISA")[0][0]]
+                ).date
+
+            # If down to less than a minute, skip
+            if CxoTime(npnt_stop) - CxoTime(npnt_start) < 60 * u.s:
+                continue
+
+            dat = fetch.Msidset(
+                ["AOACASEQ", "AOACFCT0", "AOACFCT1", "AOACFCT2"], npnt_start, npnt_stop
+            )
+            dat.interpolate(1.025)
+
+            for slot, fid_id in zip(fid_slots, fid_ids, strict=True):
+                track_msid = f"AOACFCT{slot}"
+                track_telem = dat[track_msid]
+                ok_kalm = dat["AOACASEQ"].vals == "KALM"
+                track_samples = np.count_nonzero(ok_kalm)
+                track_ok = np.count_nonzero(track_telem.vals[ok_kalm] == "TRAK")
+                track_fraction = track_ok / track_samples
+                if manvr.obsid == 62615:
+                    raise ValueError
+                fid_data.append(
+                    {
+                        "start": npnt_start,
+                        "stop": npnt_stop,
+                        "starcat_date": starcat.date,
+                        "obsid_telem": starcat.obsid,
+                        "slot": slot,
+                        "fid_id": fid_id,
+                        "track_samples": track_samples,
+                        "track_ok": track_ok,
+                        "track_fraction": track_fraction,
+                    }
+                )
+
+    return Table(fid_data)
+
+
+@functools.cache
+def get_fid_notes(data_root) -> Table:
+    """
+    Get the high background notes from the Google Sheet.
+
+    Parameters
+    ----------
+    data_root : str
+        The root directory for the data
+    Returns
+    -------
+    dat : astropy.table.Table
+        Table of notes
+    """
+    LOGGER.info(f"Reading google sheet {GSHEET_URL}")
+    dat = None
+    try:
+        dat = Table.read(GSHEET_URL, format="ascii.csv")
+    except Exception as e:
+        LOGGER.error(f"Failed to read {GSHEET_URL} with error: {e}")
+
+    if dat is not None:
+        dat.write(
+            Path(data_root) / "notes.csv",
+            format="ascii.csv",
+            overwrite=True,
+        )
+    else:
+        dat = Table.read(Path(data_root) / "notes.csv", format="ascii.csv")
+
+    return dat
+
+
+def main(args=None):
+    """
+    Main function to update the fid drop monitor data and web page.
+    """
+    opt = get_opt().parse_args(args)
+    log_run_info(LOGGER.info, opt, version=__version__)
+
+    fid_data_file = Path(opt.out_dir) / "fids_data.dat"
+    Path(opt.out_dir).mkdir(parents=True, exist_ok=True)
+
+    start = None
+    stop = None
+    fid_data_archive = None
+    min_table_start = "2011:335"
+
+    if Path(fid_data_file).exists():
+        fid_data_archive = Table.read(fid_data_file, format="ascii.ecsv")
+        start = CxoTime(fid_data_archive["start"][-1]) + 10 * u.s
+    else:
+        start = "2002:001"
+
+    if opt.start is not None:
+        # Override whatever we have in the archive
+        start = CxoTime(opt.start)
+        # And clear the archive after the supplied time
+        if fid_data_archive is not None:
+            ok = fid_data_archive["start"] < CxoTime(start).date
+            fid_data_archive = fid_data_archive[ok]
+
+    if opt.stop is not None:
+        stop = CxoTime(opt.stop)
+    else:
+        # Get the time of the last AOPCADMD data in the cxc archive
+        _, end_aopcadmd = fetch.get_time_range("AOPCADMD")
+        stop = CxoTime(end_aopcadmd)
+
+    if fid_data_archive is None:
+        fid_data = get_fid_data(start, stop)
+    else:
+        new_fid_data = get_fid_data(start, stop)
+        fid_data = vstack([fid_data_archive, new_fid_data])
+        fid_data.sort("start")
+
+    fid_data.write(fid_data_file, format="ascii.ecsv", overwrite=True)
+
+    # Filter to only include drops since min_table_start
+    ok = CxoTime(fid_data["start"]) > CxoTime(min_table_start)
+    fid_data = fid_data[ok]
+
+    # Fid drops just defined as less than 95% tracking
+    drop_events = fid_data[(fid_data["track_fraction"] < 0.95)]
+
+    # Get any info from the google sheet
+    fid_notes = get_fid_notes(opt.out_dir)
+
+    # Add the notes to the drop events
+    if len(drop_events) > 0:
+        drop_events = join(drop_events, fid_notes, keys="start", join_type="left")
+
+    # Last year of events
+    ok = CxoTime(drop_events["start"]) > CxoTime() - 365 * u.day
+    drop_events_last = drop_events[ok]
+
+    index_template_html = INDEX_TEMPLATE_PATH().read_text()
+    template = jinja2.Template(index_template_html)
+    out_html = template.render(
+        obs_events=drop_events[::-1],
+        obs_events_last=drop_events_last[::-1],
+        sheet_url=GSHEET_USER_URL,
+        start=min_table_start,
+    )
+    html_path = Path(opt.out_dir) / "index.html"
+    LOGGER.info(f"Writing HTML to {html_path}")
+    html_path.write_text(out_html)
+
+    # If any of the drops are new, send emails
+    ok = drop_events["start"] > CxoTime(start).date
+    if np.any(ok):
+        for row in drop_events[ok]:
+            LOGGER.warning(f"Fid drop in dwell starting at {row['start']}")
+            if len(opt.emails) > 0:
+                send_mail(
+                    LOGGER,
+                    opt,
+                    f"Fid drop: Obsid {row['obsid_telem']} {row['start']}",
+                    f"Fid drop in the dwell that starts at {row['start']}\n"
+                    f"Obsid {row['obsid_telem']} Fid slot {row['slot']} tracked "
+                    f"for {row['track_fraction']:.3f} fraction.\n"
+                    f"See {URL}",
+                    __file__,
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -51,7 +51,7 @@ def get_opt():
         action="append",
         dest="emails",
         default=[],
-        help="Email address for notificaion",
+        help="Email address for notification",
     )
     return parser
 
@@ -227,8 +227,6 @@ def get_fid_data(start: CxoTimeLike, stop: CxoTimeLike) -> Table:
                 track_samples = np.count_nonzero(ok_kalm)
                 track_ok = np.count_nonzero(track_telem.vals[ok_kalm] == "TRAK")
                 track_fraction = track_ok / track_samples
-                if manvr.obsid == 62615:
-                    raise ValueError
                 fid_data.append(
                     {
                         "start": npnt_start,

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -247,7 +247,7 @@ def get_fid_data(start: CxoTimeLike, stop: CxoTimeLike) -> Table:
 @functools.cache
 def get_fid_notes(data_root) -> Table:
     """
-    Get the high background notes from the Google Sheet.
+    Get the fid light notes from the Google Sheet.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

Implement a fid drop monitor using new data sources (kadi, cheta).  This is intended just to show fid drop events that are not related to other issues (scs107 etc).

Todo:
- [x] Load name for each entry
- [x] Consistent column widths

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Test output to:

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/ska_trend/pr10/
