### PR TITLE
Update get_vehicle_only_intervals to get intervals that overlap the start time

### DIFF
--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -138,8 +138,9 @@ def get_vehicle_only_intervals(
     # Filter dates outside start/stop range (using a pad at the beginning to
     # avoid missing an SCS-107 interval that has just started before the user-supplied
     # start time)
-    scs107_dates = [date for date in scs107_dates
-                    if start - continuity_pad <= CxoTime(date) <= stop]
+    scs107_dates = [
+        date for date in scs107_dates if start - continuity_pad <= CxoTime(date) <= stop
+    ]
 
     scs107_intervals = []
     for scs107_date in scs107_dates:

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -80,7 +80,7 @@ def get_vehicle_only_intervals(
     start : CxoTimeLike
         Start time filter for intervals. If ``None``, the start time is set to
         the SOSA patch start time (2011:335). Intervals that include or are after
-        with this start time are returned.
+        this start time are returned.
     stop : CxoTimeLike
         Stop time filter for intervals. If ``None``, the stop time is set
         to the current time. Intervals that include or are before
@@ -100,6 +100,8 @@ def get_vehicle_only_intervals(
     stop = CxoTime(stop) if stop is not None else CxoTime.now()
     start = sosa_patch if start is None else np.max([CxoTime(start), sosa_patch])
 
+    # Normal return to science operations after an SCS-107 is within 2 days.  I've
+    # included a 15 day pad because fetching commands is not very expensive.
     continuity_pad = 15 * u.day
 
     cmds = kc.get_cmds(start=start - continuity_pad, stop=stop)

--- a/ska_trend/fid_drop_mon/update.py
+++ b/ska_trend/fid_drop_mon/update.py
@@ -98,7 +98,7 @@ def get_vehicle_only_intervals(
     """
     sosa_patch = CxoTime("2011:335")
     stop = CxoTime(stop) if stop is not None else CxoTime.now()
-    start = sosa_patch if start is None else np.max([CxoTime(start), sosa_patch])
+    start = sosa_patch if start is None else max(CxoTime(start), sosa_patch)
 
     # Normal return to science operations after an SCS-107 is within 2 days.  I've
     # included a 15 day pad because fetching commands is not very expensive.


### PR DESCRIPTION
## Description

Update get_vehicle_only_intervals to get intervals that overlap the start time .

If a vehicle-only interval has already started by the time of "start", basically the user wants that interval too instead of ignoring it, so this updates the method to get intervals that overlap with it.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
There was an SCS107 at 2025:083:21:34:08.000 - the code in main does not pick up this interval if start is a bit after that time, even though the start and stop time do overlap a vehicle-only interval.  The code in this branch uses a pad to pick up the interval and include it.

```
(ska3-latest) flame:ska_trend jean$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
(ska3-latest) flame:ska_trend jean$ ipython
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cxotime import CxoTime

In [2]: start = "2025:083:22:34:08.000"

In [3]: stop = "2025:085:04:14:00.000"

In [4]: from ska_trend.fid_drop_mon.update import get_vehicle_only_intervals

In [5]: dat = get_vehicle_only_intervals(start, stop)

In [6]: print(dat)
<No columns>

In [7]: exit
(ska3-latest) flame:ska_trend jean$ git checkout vehicle-interval-reliability
Switched to branch 'vehicle-interval-reliability'
(ska3-latest) flame:ska_trend jean$ ipython
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: start = "2025:083:22:34:08.000"

In [2]: stop = "2025:085:04:14:00.000"

In [3]: from ska_trend.fid_drop_mon.update import get_vehicle_only_intervals

In [4]: dat = get_vehicle_only_intervals(start, stop)

In [5]: dat
Out[5]: 
<Table length=1>
      datestart              datestop      
        str21                 str21        
--------------------- ---------------------
2025:083:21:34:08.000 2025:085:03:27:00.000
```