### PR TITLE
[periscope_drift] Fix two small errors seen in weekly processing

### DIFF
--- a/ska_trend/periscope_drift/processing.py
+++ b/ska_trend/periscope_drift/processing.py
@@ -297,7 +297,7 @@ def process_interval(
     if len(errors) > 0:
         msg += f" and {len(errors)} errors"
     logger.debug(msg)
-    for error in errors:
-        logger.debug(f"    OBSID={error[0]}: {error[1]}")
+    for obsid, error in errors.items():
+        logger.debug(f"    OBSID={obsid}: {error}")
 
     return observations, summary, errors

--- a/ska_trend/periscope_drift/reports.py
+++ b/ska_trend/periscope_drift/reports.py
@@ -110,7 +110,7 @@ def get_data_for_interval(start, stop, observations, sources, idx=0):
     )
 
     kwargs = {
-        "responsive": True,
+        "config": {"responsive": True},
         "full_html": False,
         "include_plotlyjs": "cdn",
     }


### PR DESCRIPTION
fix two small errors seen in weekly processing
- wrongly reporting at  the end,
- passing responsive flag to plotly the wrong way

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I re-ran the periscope drift with this fix (still the same page at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/ska_trend/pr13/periscope_drift/)
