### PR TITLE
Remove symlinks in obsid dirs and make --stop imply --no-last-links

### DIFF
--- a/ska_trend/centroid_dashboard/app.py
+++ b/ska_trend/centroid_dashboard/app.py
@@ -90,8 +90,8 @@ def get_opt():
     )
     parser.add_argument(
         "--no-last-links",
-        help="Do not create redirect link files to the last observation "
-        "(use for reprocessing a past interval that does not come up to the present)",
+        help="Do not create redirect link files to the last observation. This is "
+        "automatically set if ``--stop`` is supplied.",
         action="store_true",
     )
     parser.add_argument(
@@ -1345,6 +1345,12 @@ def main(args=None):
 
     opt = get_opt().parse_args(args)
     logger.setLevel(opt.log_level)
+
+    # Require --no-last-links if a non-NOW stop was specified for reprocessing an
+    # interval. Otherwise it is too easy to corrupt the last links accidentally.
+    if opt.stop is not CxoTime.NOW:
+        logger.info("--stop time specified, setting --no-last-links")
+        opt.no_last_links = True
 
     stop = CxoTime(opt.stop)
     start = CxoTime(opt.start) if opt.start else stop - NDAYS_DEFAULT * u.day

--- a/ska_trend/centroid_dashboard/app.py
+++ b/ska_trend/centroid_dashboard/app.py
@@ -1328,6 +1328,11 @@ def make_obsid_dir_links(obs: Observation):
     """
     out_dir = obs.path.obsid_two_obsid_dir
     out_dir.mkdir(parents=True, exist_ok=True)
+    # Remove any symbolic link in out_dir
+    for path in out_dir.iterdir():
+        if path.is_symlink():
+            logger.info(f"Removing existing symlink {path}")
+            path.unlink()
     write_redirect_html(
         target_dir=obs.path.report_dir,
         redirect_file_path=out_dir / "index.html",


### PR DESCRIPTION
## Description

The previous version of centroid_dashboard used to generate most of the existing data structure used symlinks to establish a connection between a `<LOAD>/<obsid>` directory and the legacy `<2-digit-obsid>/<obsid>` structure. This created an `index.html` symlink in the latter directory. The new processing instead writes `index.html` as a proper redirect to the load-obsid `index.html`. But reprocessing in the old structure would follow the symlink and *overwrite* the load-obsid/index.html with a redirect and break everything. This fixes that by removing any symlinks that are found.

This PR also changes processing so that if ``--stop`` is supplied then that forces ``--no-last-links``. Basically if you are reprocessing an "interior" time interval then writing the `last` links is always a bad idea. Even though the command line option is there and documented, it would be very easy to forget to do this.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I ran this as `aca` on the flight archive, with a plan to restore from the netapp if anything went wrong.
```
cd ~/git/ska_trend
# Checked out to this branch
source /proj/sot/ska3/aca/bin/ska_envs.csh

# Reprocess from Sep-15 2025 to present
python -m ska_trend.centroid_dashboard.app --data-root /proj/sot/ska/www/ASPECT_ICXC/centroid_reports --start 2025-09-15 --remove index.html --remove info.html --remove kalman_plot_done

# Reprocess a 1-day interior interval
python -m ska_trend.centroid_dashboard.app --data-root /proj/sot/ska/www/ASPECT_ICXC/centroid_reports --start 2025-09-16 --stop 2025-09-17 --remove index.html
```
After this I navigated around and checked the last links. Everything worked as expected.

