### PR TITLE
Small changes in periscope_drift

### DIFF
--- a/ska_trend/periscope_drift/observation.py
+++ b/ska_trend/periscope_drift/observation.py
@@ -444,7 +444,7 @@ class PeriscopeDriftData(StorableClass):
 
         source_ids = list(set(data.keys()) & set(src["id"]))
 
-        src = src[np.in1d(src["id"], source_ids)]
+        src = src[np.isin(src["id"], source_ids)]
         data = {sid: data[sid] for sid in source_ids}
         return ObservationData(
             summary=self.get_summary(),

--- a/ska_trend/periscope_drift/plotly.py
+++ b/ska_trend/periscope_drift/plotly.py
@@ -80,7 +80,7 @@ def plot_sources(periscope_drift_data, ids=None):
     """
     ids = periscope_drift_data.sources["id"] if ids is None else ids
     src = periscope_drift_data.sources
-    src = src[np.in1d(src["id"], ids)]
+    src = src[np.isin(src["id"], ids)]
 
     n_x = 6
     n_y = len(src) // n_x + int(len(src) % n_x > 0)

--- a/ska_trend/periscope_drift/processing.py
+++ b/ska_trend/periscope_drift/processing.py
@@ -413,7 +413,7 @@ def update_sources(sources, obsids, filename=None):
     if filename.exists():
         # if the file exists, replace the entries with the newly processed ones
         prev_sources = get_sources(filename)
-        prev_sources = prev_sources[~np.in1d(prev_sources["obsid"], obsids)]
+        prev_sources = prev_sources[~np.isin(prev_sources["obsid"], obsids)]
         if not sources or len(sources) == 0:
             all_sources = prev_sources
         else:

--- a/ska_trend/periscope_drift/reports.py
+++ b/ska_trend/periscope_drift/reports.py
@@ -341,7 +341,7 @@ def write_report(
         sources = processing.get_sources()
 
         report_sources = sources[
-            np.in1d(sources["obsid"], processing.get_obsids(start, stop))
+            np.isin(sources["obsid"], processing.get_obsids(start, stop))
         ]
 
         # select only sources that are selected according to fixed criteria


### PR DESCRIPTION
## Description

Replace `np.in1d` with `np.isin`

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
