### PR TITLE
Change endianness of periscope drift sources table upon reading

### DIFF
--- a/ska_trend/periscope_drift/processing.py
+++ b/ska_trend/periscope_drift/processing.py
@@ -393,7 +393,9 @@ def get_sources(filename=None):
     filename = SOURCES_FILE if filename is None else filename
     if not filename.exists():
         raise FileNotFoundError(f"Sources file {filename} not found")
-    return Table.read(filename)
+    # https://github.com/astropy/astropy/issues/4069
+    # we want to convert to native endiannes upon read, because some plotly functions expect it
+    return Table(Table.read(filename).as_array())
 
 
 def update_sources(sources, obsids, filename=None):

--- a/ska_trend/periscope_drift/processing.py
+++ b/ska_trend/periscope_drift/processing.py
@@ -393,9 +393,11 @@ def get_sources(filename=None):
     filename = SOURCES_FILE if filename is None else filename
     if not filename.exists():
         raise FileNotFoundError(f"Sources file {filename} not found")
+    # we want to convert to native byteorder upon reading, because some plotly functions expect it,
+    # and the following is the easiest way to do it
     # https://github.com/astropy/astropy/issues/4069
-    # we want to convert to native endiannes upon read, because some plotly functions expect it
-    return Table(Table.read(filename).as_array())
+    # https://github.com/astropy/astropy/pull/4080
+    return Table(Table.read(filename).as_array(keep_byteorder=False))
 
 
 def update_sources(sources, obsids, filename=None):


### PR DESCRIPTION
## Description

This fixes the outdated periscope drift dashboard by resetting the endianness of table when it is read from file. I don't know why this worked and then it stopped working.

The data itself is up to date. This error happens only when generating the report.

The reason why the periscope drift dashboard is not updating is a crash in a plotly plot `to_html` method:
```
  File "/proj/sot/ska3/aca/lib/python3.13/site-packages/plotly/basedatatypes.py", line 3606, in to_html
    return pio.to_html(self, *args, **kwargs)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/proj/sot/ska3/aca/lib/python3.13/site-packages/plotly/io/_html.py", line 146, in to_html
    jdata = to_json_plotly(fig_dict.get("data", []))
  File "/proj/sot/ska3/aca/lib/python3.13/site-packages/plotly/io/_json.py", line 172, in to_json_plotly
    return _safe(orjson.dumps(cleaned, option=opts).decode("utf8"), _swap_orjson)
                 ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: numpy array is not native-endianness
```

Astropy table does not automatically convert endianness (link in the comment committed in this PR).

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [X] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Do this in a notebook (should fail in main, succeed in the branch):
```
from cxotime import CxoTime

from ska_trend.periscope_drift import processing, plotly

start = CxoTime("2026:080")
stop = CxoTime("2026:090")
sources = processing.get_sources()
processing
plotly.get_chi2_figure(sources)
```
