### PR TITLE
Add slicing to CentroidResidualsLite and add tests

### DIFF
--- a/ska_trend/centroid_dashboard/app.py
+++ b/ska_trend/centroid_dashboard/app.py
@@ -2,6 +2,7 @@ import argparse
 import copy
 import functools
 import json
+import numbers
 import os
 import pickle
 import shutil
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 # Update guide metrics file with new obsids between NOW and (NOW - NDAYS_DEFAULT) days
 NDAYS_DEFAULT = 7
 SKA = Path(os.environ["SKA"])
+DATA_ROOT_DEFAULT = SKA / "data" / "centroid_dashboard" / "centroid_reports"
 
 # Count of sporadic exceptions for testing. See `raise_sporadic_exc_for_testing`.
 SPORADIC_EXC_COUNT = 0
@@ -141,14 +143,124 @@ def get_template(template_name: str) -> jinja2.Template:
 class CentroidResidualsLite:
     """Lite version of CentroidResiduals.
 
-    This provides the attributes that are needed for processing in this application and
+    This follows the minimal API for ``chandra_aca.centroid_resids.CentroidResiduals``
+    and provides the attributes that are needed for processing in this application and
     are available in the centroid residuals file.
+
+    Attributes are:
+    - dyags: Y-angle centroid residuals in arcsec
+    - dzags: Z-angle centroid residuals in arcsec
+    - yag_times: Timestamps for Y-angle residuals (CXC seconds)
+    - zag_times: Timestamps for Z-angle residuals (CXC seconds)
+
+    Indexing and slicing are supported. There are three modes:
+
+    **Integer or array indexing** — standard NumPy index applied to all arrays::
+
+        cr[0]          # first sample
+        cr[-1]         # last sample
+        cr[[0, 2, 4]]  # select specific samples by index
+        cr[mask]       # boolean mask selection
+
+    **Integer slice** — standard NumPy slice applied to all arrays::
+
+        cr[10:50]      # samples 10 through 49
+        cr[::2]        # every other sample
+
+    **Time-based slice** — triggered when either ``start`` or ``stop`` is a
+    non-integer float (i.e. a CXC seconds timestamp). Positive offsets are
+    relative to the earliest time in the data; negative offsets are relative to
+    the latest time. A ``step`` is not supported for time-based slices::
+
+        t0 = cr.yag_times[0]
+        cr[0.0:500.0]        # first 500 seconds of data (offset from t_min)
+        cr[-300.0:]          # last 300 seconds of data (offset from t_max)
+        cr[:600.0]           # from start up to 600 seconds after t_min
     """
 
     dyags: npt.NDArray
     dzags: npt.NDArray
     yag_times: npt.NDArray
     zag_times: npt.NDArray
+
+    def __getitem__(self, item):
+        if not isinstance(item, slice) or not self._is_time_slice(item):
+            return self.__class__(
+                self.dyags[item],
+                self.dzags[item],
+                self.yag_times[item],
+                self.zag_times[item],
+            )
+
+        if item.step is not None:
+            raise TypeError("time-based slicing does not support a step")
+
+        time_min, time_max = self._get_time_limits()
+        yag_slice = self._slice_by_time(
+            self.dyags, self.yag_times, item, time_min, time_max
+        )
+        zag_slice = self._slice_by_time(
+            self.dzags, self.zag_times, item, time_min, time_max
+        )
+
+        return self.__class__(
+            yag_slice[0],
+            zag_slice[0],
+            yag_slice[1],
+            zag_slice[1],
+        )
+
+    @staticmethod
+    def _is_time_slice(item: slice) -> bool:
+        return any(
+            isinstance(bound, numbers.Real) and not isinstance(bound, numbers.Integral)
+            for bound in (item.start, item.stop)
+            if bound is not None
+        )
+
+    def _get_time_limits(self) -> tuple[float, float]:
+        time_min = np.inf
+        time_max = -np.inf
+        if len(self.yag_times) > 0:
+            time_min = min(time_min, float(np.min(self.yag_times)))
+            time_max = max(time_max, float(np.max(self.yag_times)))
+        if len(self.zag_times) > 0:
+            time_min = min(time_min, float(np.min(self.zag_times)))
+            time_max = max(time_max, float(np.max(self.zag_times)))
+        return time_min, time_max
+
+    @staticmethod
+    def _get_time_bound(
+        bound: object, time_min: float, time_max: float
+    ) -> float | None:
+        if bound is None:
+            return None
+
+        if isinstance(bound, numbers.Real) and not isinstance(bound, numbers.Integral):
+            bound = float(bound)
+            return time_max + bound if bound < 0 else time_min + bound
+
+        return float(bound)
+
+    @classmethod
+    def _slice_by_time(
+        cls,
+        vals: npt.NDArray,
+        times: npt.NDArray,
+        item: slice,
+        time_min: float,
+        time_max: float,
+    ) -> tuple[npt.NDArray, npt.NDArray]:
+        start = cls._get_time_bound(item.start, time_min, time_max)
+        stop = cls._get_time_bound(item.stop, time_min, time_max)
+
+        ok = np.ones(len(times), dtype=bool)
+        if start is not None:
+            ok &= times >= start
+        if stop is not None:
+            ok &= times < stop
+
+        return vals[ok], times[ok]
 
 
 class Paths:
@@ -799,7 +911,10 @@ def get_centroid_resids_from_file(
 
 
 def get_centroid_resids_for_obsid(
-    obsid_sched: int, source: str | None = None, data_root: Path | None = None
+    obsid_sched: int,
+    source: str | None = None,
+    data_root: Path | None = None,
+    duration: float | None = None,
 ) -> dict[int, CentroidResidualsLite] | None:
     """Get centroid residuals from flight telemetry for an observation.
 
@@ -827,27 +942,20 @@ def get_centroid_resids_for_obsid(
         ``obsid_sched`` if this is unique.
     data_root : Path | None
         Data root directory (default=$SKA/data/centroid_dashboard/centroid_reports).
+    duration : float | None
+        If not None, trim the centroid residuals to duration in seconds. If positive,
+        then return duration seconds from the start of the observation. If negative,
+        trim return the last duration seconds from the end of the observation.
 
     Returns
     -------
     dict[int, CentroidResidualsLite]
         Dictionary of CentroidResidualsLite objects keyed by slot
     """
-    if data_root is None:
-        data_root = (
-            Path(os.environ["SKA"]) / "data" / "centroid_dashboard" / "centroid_reports"
-        )
-    else:
-        data_root = Path(data_root)
+    data_root = DATA_ROOT_DEFAULT if data_root is None else Path(data_root)
 
     if source is None:
-        obss = kc.get_observations(obsid_sched=obsid_sched)
-        if len(obss) == 0:
-            raise ValueError(f"no matching observations for {obsid_sched=}")
-        elif len(obss) > 1:
-            raise ValueError(
-                f"multiple matching observations for {obsid_sched=}:\n{obss}"
-            )
+        obss = kc.get_observation(obsid_sched=obsid_sched)
         source = obss[0]["source"]
 
     obs_stub = ObservationFromInfo(
@@ -861,11 +969,19 @@ def get_centroid_resids_for_obsid(
             f"Centroid residuals not found for {obsid_sched=} and {source=}"
             f" in {obs_stub.path.centroid_resids_pkl}"
         )
-    for cr in crs.values():
+
+    # Munge the yag/zag data type and trim by duration if requested.
+    out = {}
+    for slot, cr in crs.items():
         cr.dyags = cr.dyags.astype(np.float64)
         cr.dzags = cr.dzags.astype(np.float64)
 
-    return crs
+        if duration is not None:
+            duration = float(duration)
+            cr = cr[:duration] if duration > 0 else cr[duration:]  # noqa: PLW2901
+        out[slot] = cr
+
+    return out
 
 
 def get_centroid_resids(

--- a/ska_trend/centroid_dashboard/app.py
+++ b/ska_trend/centroid_dashboard/app.py
@@ -914,7 +914,6 @@ def get_centroid_resids_for_obsid(
     obsid_sched: int,
     source: str | None = None,
     data_root: Path | None = None,
-    duration: float | None = None,
 ) -> dict[int, CentroidResidualsLite] | None:
     """Get centroid residuals from flight telemetry for an observation.
 
@@ -942,10 +941,6 @@ def get_centroid_resids_for_obsid(
         ``obsid_sched`` if this is unique.
     data_root : Path | None
         Data root directory (default=$SKA/data/centroid_dashboard/centroid_reports).
-    duration : float | None
-        If not None, trim the centroid residuals to duration in seconds. If positive,
-        then return duration seconds from the start of the observation. If negative,
-        trim return the last duration seconds from the end of the observation.
 
     Returns
     -------
@@ -971,17 +966,11 @@ def get_centroid_resids_for_obsid(
         )
 
     # Munge the yag/zag data type and trim by duration if requested.
-    out = {}
-    for slot, cr in crs.items():
+    for cr in crs.values():
         cr.dyags = cr.dyags.astype(np.float64)
         cr.dzags = cr.dzags.astype(np.float64)
 
-        if duration is not None:
-            duration = float(duration)
-            cr = cr[:duration] if duration > 0 else cr[duration:]  # noqa: PLW2901
-        out[slot] = cr
-
-    return out
+    return crs
 
 
 def get_centroid_resids(

--- a/ska_trend/centroid_dashboard/app.py
+++ b/ska_trend/centroid_dashboard/app.py
@@ -965,7 +965,7 @@ def get_centroid_resids_for_obsid(
             f" in {obs_stub.path.centroid_resids_pkl}"
         )
 
-    # Munge the yag/zag data type and trim by duration if requested.
+    # Munge the yag/zag data type
     for cr in crs.values():
         cr.dyags = cr.dyags.astype(np.float64)
         cr.dzags = cr.dzags.astype(np.float64)

--- a/ska_trend/centroid_dashboard/tests/test_app.py
+++ b/ska_trend/centroid_dashboard/tests/test_app.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pytest
 
@@ -52,16 +51,7 @@ def test_time_slice_with_step_raises(crs: CentroidResidualsLite) -> None:
 def test_get_centroid_resids_for_obsid_with_source() -> None:
     crs = cent_app.get_centroid_resids_for_obsid(29833, source="FEB0226A")
 
-    assert (
-        crs.keys()
-        == {
-            np.int64(3),
-            np.int64(4),
-            np.int64(5),
-            np.int64(6),
-            np.int64(7),
-        }.keys()
-    )
+    assert list(crs.keys()) == [3, 4, 5, 6, 7]
 
 
 def test_get_centroid_resids_for_obsid_without_source_raises_value_error() -> None:

--- a/ska_trend/centroid_dashboard/tests/test_app.py
+++ b/ska_trend/centroid_dashboard/tests/test_app.py
@@ -1,0 +1,70 @@
+
+import numpy as np
+import pytest
+
+import ska_trend.centroid_dashboard.app as cent_app
+
+CentroidResidualsLite = cent_app.CentroidResidualsLite
+
+
+@pytest.fixture
+def crs() -> CentroidResidualsLite:
+    return CentroidResidualsLite(
+        dyags=np.array([1.0, 2.0, 3.0, 4.0]),
+        dzags=np.array([10.0, 20.0, 30.0, 40.0]),
+        yag_times=np.array([1000.0, 1200.0, 1400.0, 1600.0]),
+        zag_times=np.array([1050.0, 1250.0, 1450.0, 1650.0]),
+    )
+
+
+def test_slice_time_window_from_start(crs: CentroidResidualsLite) -> None:
+    out = crs[:500.0]
+
+    np.testing.assert_array_equal(out.dyags, np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(out.dzags, np.array([10.0, 20.0, 30.0]))
+    np.testing.assert_array_equal(out.yag_times, np.array([1000.0, 1200.0, 1400.0]))
+    np.testing.assert_array_equal(out.zag_times, np.array([1050.0, 1250.0, 1450.0]))
+
+
+def test_slice_time_window_from_end(crs: CentroidResidualsLite) -> None:
+    out = crs[-500.0:]
+
+    np.testing.assert_array_equal(out.dyags, np.array([2.0, 3.0, 4.0]))
+    np.testing.assert_array_equal(out.dzags, np.array([20.0, 30.0, 40.0]))
+    np.testing.assert_array_equal(out.yag_times, np.array([1200.0, 1400.0, 1600.0]))
+    np.testing.assert_array_equal(out.zag_times, np.array([1250.0, 1450.0, 1650.0]))
+
+
+def test_slice_by_index_still_works(crs: CentroidResidualsLite) -> None:
+    out = crs[1:3]
+
+    np.testing.assert_array_equal(out.dyags, np.array([2.0, 3.0]))
+    np.testing.assert_array_equal(out.dzags, np.array([20.0, 30.0]))
+    np.testing.assert_array_equal(out.yag_times, np.array([1200.0, 1400.0]))
+    np.testing.assert_array_equal(out.zag_times, np.array([1250.0, 1450.0]))
+
+
+def test_time_slice_with_step_raises(crs: CentroidResidualsLite) -> None:
+    with pytest.raises(TypeError, match="time-based slicing does not support a step"):
+        _ = crs[-500.0::2]
+
+
+def test_get_centroid_resids_for_obsid_with_source() -> None:
+    crs = cent_app.get_centroid_resids_for_obsid(29833, source="FEB0226A")
+
+    assert (
+        crs.keys()
+        == {
+            np.int64(3),
+            np.int64(4),
+            np.int64(5),
+            np.int64(6),
+            np.int64(7),
+        }.keys()
+    )
+
+
+def test_get_centroid_resids_for_obsid_without_source_raises_value_error() -> None:
+    match = r"expected one observation matching the filter criteria but got 2"
+    with pytest.raises(ValueError, match=match):
+        cent_app.get_centroid_resids_for_obsid(29833)


### PR DESCRIPTION
## Description

This makes it a bit easier to use centroid residuals from the centroids dashboard by allowing relative-time based slicing as well as normal getitem functionality. It also adds some tests.

## Requires
- https://github.com/sot/kadi/pull/387

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
- Adds slicing and indexing to `CentroidResidualsLite`

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  ska_trend git:(centroid-residuals-lite-slice) git rev-parse --short HEAD
0ade2a0
(ska3) ➜  ska_trend git:(centroid-residuals-lite-slice) env PYTHONPATH=/Users/aldcroft/git/kadi pytest
===================================== test session starts =====================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 6 items                                                                             

ska_trend/centroid_dashboard/tests/test_app.py ......                                   [100%]

====================================== 6 passed in 3.37s ======================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
