### PR TITLE
Small fixes in periscope drift (parse_time_arg and fig resize)

### DIFF
--- a/ska_trend/periscope_drift/scripts/periscope_drift_regenerate_reports.py
+++ b/ska_trend/periscope_drift/scripts/periscope_drift_regenerate_reports.py
@@ -4,15 +4,14 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
 from pathlib import Path
 
 import ska_helpers
 from cxotime import CxoTime
-from cxotime import units as u
 
 from ska_trend.periscope_drift import reports
+from ska_trend.time_utils import parse_time_arg
 
 logger = logging.getLogger("periscope_drift")
 
@@ -25,7 +24,11 @@ def get_parser():
         type=Path,
         help="Output directory",
     )
-    parser.add_argument("--start", default="-1825d", help="Start of report interval")
+    parser.add_argument(
+        "--start",
+        default="stop-1825d",
+        help="Start of report interval (e.g. stop-1825d or a date). Default: stop-1825d",
+    )
     parser.add_argument("--stop", default=None)
     parser.add_argument(
         "--overwrite",
@@ -100,10 +103,7 @@ def main():
 
     stop = now if args.stop is None else CxoTime(args.stop)
 
-    if re.match(r"[-+]? [0-9]* \.? [0-9]+ d", args.start, re.VERBOSE):
-        start_report = stop + float(args.start[:-1]) * u.d
-    else:
-        start_report = CxoTime(args.start)
+    start_report = parse_time_arg(args.start, stop)
 
     reports.write_report(
         start=start_report,

--- a/ska_trend/periscope_drift/scripts/periscope_drift_regenerate_reports.py
+++ b/ska_trend/periscope_drift/scripts/periscope_drift_regenerate_reports.py
@@ -103,7 +103,7 @@ def main():
 
     stop = now if args.stop is None else CxoTime(args.stop)
 
-    start_report = parse_time_arg(args.start, stop)
+    start_report = parse_time_arg(args.start, stop=stop)
 
     reports.write_report(
         start=start_report,

--- a/ska_trend/periscope_drift/scripts/periscope_drift_reports.py
+++ b/ska_trend/periscope_drift/scripts/periscope_drift_reports.py
@@ -4,15 +4,14 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
 from pathlib import Path
 
 import ska_helpers
 from cxotime import CxoTime
-from cxotime import units as u
 
 from ska_trend.periscope_drift import processing, reports
+from ska_trend.time_utils import parse_time_arg
 
 logger = logging.getLogger("periscope_drift")
 
@@ -27,14 +26,14 @@ def get_parser():
     )
     parser.add_argument(
         "--start",
-        default="-60d",
-        help="Start of processing interval. Default: NOW - 60d",
+        default="stop-60d",
+        help="Start of processing interval (e.g. stop-60d or a date). Default: stop-60d",
     )
     parser.add_argument("--stop", default=None)
     parser.add_argument(
         "--start-report",
-        default="-1825d",
-        help="Start of report interval. Default: NOW - 1825d (5 years ago)",
+        default="stop-1825d",
+        help="Start of report interval (e.g. stop-1825d or a date). Default: stop-1825d",
     )
     parser.add_argument(
         "--workdir",
@@ -112,15 +111,8 @@ def main():
 
     stop = now if args.stop is None else CxoTime(args.stop)
 
-    if re.match(r"[-+]? [0-9]* \.? [0-9]+ d", args.start_report, re.VERBOSE):
-        start_report = stop + float(args.start_report[:-1]) * u.d
-    else:
-        start_report = CxoTime(args.start_report)
-
-    if re.match(r"[-+]? [0-9]* \.? [0-9]+ d", args.start, re.VERBOSE):
-        start_process = stop + float(args.start[:-1]) * u.d
-    else:
-        start_process = CxoTime(args.start)
+    start_report = parse_time_arg(args.start_report, stop)
+    start_process = parse_time_arg(args.start, stop)
 
     errors = processing.process_interval(
         start_process,

--- a/ska_trend/periscope_drift/scripts/periscope_drift_reports.py
+++ b/ska_trend/periscope_drift/scripts/periscope_drift_reports.py
@@ -111,8 +111,8 @@ def main():
 
     stop = now if args.stop is None else CxoTime(args.stop)
 
-    start_report = parse_time_arg(args.start_report, stop)
-    start_process = parse_time_arg(args.start, stop)
+    start_report = parse_time_arg(args.start_report, stop=stop)
+    start_process = parse_time_arg(args.start, stop=stop)
 
     errors = processing.process_interval(
         start_process,

--- a/ska_trend/periscope_drift/templates/periscope_drift/index.html
+++ b/ska_trend/periscope_drift/templates/periscope_drift/index.html
@@ -18,6 +18,19 @@
 		h2 {
 			color: #990000;
 		}
+
+		/* Keep inactive tab panes in the layout at full width (clipped to zero height) instead
+		   of display:none, so Plotly always draws its figures at the correct size and they are
+		   immediately interactive. Avoids the hidden-render resize/click problems. */
+		.tab-content > .tab-pane {
+			display: block !important;
+			height: 0;
+			overflow: hidden;
+		}
+		.tab-content > .tab-pane.active {
+			height: auto;
+			overflow: visible;
+		}
 	</style>
   <title>Periscope Trending Report</title>
 </head>
@@ -197,6 +210,7 @@
 	});
   </script>
   {% endfor %}
+
 
 </body>
 </html>

--- a/ska_trend/tests/test_time_utils.py
+++ b/ska_trend/tests/test_time_utils.py
@@ -1,0 +1,21 @@
+from astropy import units as u
+from cxotime import CxoTime
+
+from ska_trend.time_utils import parse_time_arg
+
+
+def test_parse_time_arg_stop_relative():
+    stop = CxoTime("2026-02-02")
+
+    # days and years back, relative to stop
+    assert parse_time_arg("stop-90d", stop).date == (stop - 90 * u.day).date
+    assert parse_time_arg("stop-5yr", stop).date == (stop - 5 * u.yr).date
+
+    # forward offset, and whitespace-tolerant
+    assert parse_time_arg("stop+30d", stop).date == (stop + 30 * u.day).date
+    assert parse_time_arg("stop + 30 d", stop).date == (stop + 30 * u.day).date
+
+
+def test_parse_time_arg_absolute():
+    stop = CxoTime("2026-02-02")
+    assert parse_time_arg("2020-01-01", stop).date == CxoTime("2020-01-01").date

--- a/ska_trend/tests/test_time_utils.py
+++ b/ska_trend/tests/test_time_utils.py
@@ -4,18 +4,25 @@ from cxotime import CxoTime
 from ska_trend.time_utils import parse_time_arg
 
 
-def test_parse_time_arg_stop_relative():
+def test_parse_time_arg_reference_relative():
     stop = CxoTime("2026-02-02")
 
-    # days and years back, relative to stop
-    assert parse_time_arg("stop-90d", stop).date == (stop - 90 * u.day).date
-    assert parse_time_arg("stop-5yr", stop).date == (stop - 5 * u.yr).date
+    # days and years back, relative to the named reference
+    assert parse_time_arg("stop-90d", stop=stop).date == (stop - 90 * u.day).date
+    assert parse_time_arg("stop-5yr", stop=stop).date == (stop - 5 * u.yr).date
 
     # forward offset, and whitespace-tolerant
-    assert parse_time_arg("stop+30d", stop).date == (stop + 30 * u.day).date
-    assert parse_time_arg("stop + 30 d", stop).date == (stop + 30 * u.day).date
+    assert parse_time_arg("stop+30d", stop=stop).date == (stop + 30 * u.day).date
+    assert parse_time_arg("stop + 30 d", stop=stop).date == (stop + 30 * u.day).date
+
+    # the reference name is agnostic: any keyword works
+    start = CxoTime("2020-01-01")
+    assert parse_time_arg("start+10d", start=start).date == (start + 10 * u.day).date
+
+    # the bare reference name (no offset) returns that reference time
+    assert parse_time_arg("stop", stop=stop).date == stop.date
 
 
 def test_parse_time_arg_absolute():
     stop = CxoTime("2026-02-02")
-    assert parse_time_arg("2020-01-01", stop).date == CxoTime("2020-01-01").date
+    assert parse_time_arg("2020-01-01", stop=stop).date == CxoTime("2020-01-01").date

--- a/ska_trend/time_utils.py
+++ b/ska_trend/time_utils.py
@@ -7,32 +7,42 @@ from cxotime import CxoTime, TimeDelta
 __all__ = ["parse_time_arg"]
 
 
-def parse_time_arg(value, stop):
+def parse_time_arg(value, **references):
     """
     Parse a report-time CLI argument.
 
-    Two forms are accepted:
+    ``value`` is either:
 
-    - ``"stop<delta>"`` is interpreted relative to ``stop``, where ``<delta>`` is passed straight
-      to ``TimeDelta`` (astropy ``quantity_str`` format). Examples: ``"stop-90d"``, ``"stop-5yr"``,
-      ``"stop+30d"`` (units: ``yr d hr min s``). Using ``stop`` as the prefix (rather than a bare
-      leading ``-``) keeps argparse from mistaking the value for an option flag.
-    - Anything else is passed to ``CxoTime``: an absolute date (e.g. ``"2026-02-02"``) or a
+    - a named reference followed by a ``TimeDelta`` offset, e.g. ``"stop-90d"`` or ``"start+10d"``.
+      The reference name must match one of the keyword arguments; the offset (astropy
+      ``quantity_str`` format, units ``yr d hr min s``) is added to that reference time. Using a
+      name prefix (rather than a bare leading ``-``) keeps argparse from mistaking the value for an
+      option flag. The reference name alone (no offset) returns that reference time.
+    - anything else, passed to ``CxoTime``: an absolute date (e.g. ``"2026-02-02"``) or a
       now-relative offset (e.g. ``"-90d"``).
+
+    Examples
+    --------
+    >>> parse_time_arg("stop-90d", stop=stop)      # stop - 90 days
+    >>> parse_time_arg("start+10d", start=start)   # start + 10 days
+    >>> parse_time_arg("2026-02-02", stop=stop)    # absolute date
 
     Parameters
     ----------
     value : str
         The CLI argument value.
-    stop : CxoTime
-        The reference stop time for ``"stop<delta>"`` forms.
+    **references : CxoTime
+        Named reference times that ``value`` may be expressed relative to.
 
     Returns
     -------
     CxoTime
     """
     value = str(value).strip()
-    if value.startswith("stop"):
-        delta = value[len("stop") :].strip()
-        return stop + TimeDelta(delta, format="quantity_str")
+    for name, ref in references.items():
+        if value.startswith(name):
+            delta = value[len(name) :].strip()
+            if not delta:
+                return CxoTime(ref)
+            return CxoTime(ref) + TimeDelta(delta, format="quantity_str")
     return CxoTime(value)

--- a/ska_trend/time_utils.py
+++ b/ska_trend/time_utils.py
@@ -1,0 +1,38 @@
+"""
+Small time-parsing helpers shared by the report CLI scripts.
+"""
+
+from cxotime import CxoTime, TimeDelta
+
+__all__ = ["parse_time_arg"]
+
+
+def parse_time_arg(value, stop):
+    """
+    Parse a report-time CLI argument.
+
+    Two forms are accepted:
+
+    - ``"stop<delta>"`` is interpreted relative to ``stop``, where ``<delta>`` is passed straight
+      to ``TimeDelta`` (astropy ``quantity_str`` format). Examples: ``"stop-90d"``, ``"stop-5yr"``,
+      ``"stop+30d"`` (units: ``yr d hr min s``). Using ``stop`` as the prefix (rather than a bare
+      leading ``-``) keeps argparse from mistaking the value for an option flag.
+    - Anything else is passed to ``CxoTime``: an absolute date (e.g. ``"2026-02-02"``) or a
+      now-relative offset (e.g. ``"-90d"``).
+
+    Parameters
+    ----------
+    value : str
+        The CLI argument value.
+    stop : CxoTime
+        The reference stop time for ``"stop<delta>"`` forms.
+
+    Returns
+    -------
+    CxoTime
+    """
+    value = str(value).strip()
+    if value.startswith("stop"):
+        delta = value[len("stop") :].strip()
+        return stop + TimeDelta(delta, format="quantity_str")
+    return CxoTime(value)


### PR DESCRIPTION
## Description

This PR makes a few fixes in `ska_trend.periscope_drift`:
- adds a little function in a new `time_utils` submodule. This function can be used to parse the time arguments in periscope drift (like `--start` and `--stop`) so they can use the standard format (like `start+10d` or `stop-20d`). The current master tries to use things like `-90d` which just does not work.
- Fix the responsive resizing of plotly figures in hidden tabs (in current master, plotly figures in hidden tabs do not scale, so if one resizes the browser window and switches the tab, the figure is the wrong size). This is done by changing the way tabs hide their contents (instead of using the `display` property, it uses the `height` property)
- This last change also happens to fix another issue: in current master, clicking on markers in tabs that are initially hidden does not open the URL for the given source details.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
