### PR TITLE
Astromon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ entry_points = {
         "ska_trend_centroid_dashboard=ska_trend.centroid_dashboard.app:main",
         "ska_trend_centroid_dashboard_check_continuity=ska_trend.centroid_dashboard.check_continuity:main",
         "ska_trend_fid_drop_mon_update=ska_trend.fid_drop_mon.update:main",
+        "ska_trend_astromon=ska_trend.astromon.scripts.astromon_reports:main",
         "ska_trend_periscope_drift=ska_trend.periscope_drift.scripts.periscope_drift_reports:main",
         "ska_trend_periscope_drift_regions=ska_trend.periscope_drift.scripts.periscope_drift_regions:main",
         "ska_trend_periscope_drift_regenerate=ska_trend.periscope_drift.scripts.periscope_drift_regenerate_reports:main",
@@ -32,6 +33,8 @@ setup(
     entry_points=entry_points,
     packages=[
         "ska_trend",
+        "ska_trend.astromon",
+        "ska_trend.astromon.scripts",
         "ska_trend.wrong_box_anom",
         "ska_trend.bad_periscope_gradient",
         "ska_trend.centroid_dashboard",
@@ -58,6 +61,11 @@ setup(
             "task_schedule.cfg",
             "templates/periscope_drift/index.html",
             "templates/periscope_drift/source_report.html",
+        ],
+        "ska_trend.astromon": [
+            "task_schedule.cfg",
+            "templates/astromon/index.html",
+            "templates/astromon/source_report.html",
         ],
     },
 )

--- a/ska_trend/astromon/__init__.py
+++ b/ska_trend/astromon/__init__.py
@@ -1,0 +1,1 @@
+from .data import get_matches, get_obsid_image, get_source_markers

--- a/ska_trend/astromon/data.py
+++ b/ska_trend/astromon/data.py
@@ -28,6 +28,7 @@ logger = logging.getLogger("astromon")
 __all__ = [
     "get_matches",
     "binned_offsets",
+    "simbad_url",
     "get_obsid_image",
     "get_source_markers",
     "crop_box",
@@ -195,7 +196,7 @@ def get_obsid_image(obsid, archive_dir):
     return image, wcs
 
 
-def _simbad_url(loc):
+def simbad_url(loc):
     ra = loc.ra.to_string(unit="hour")
     dec = loc.dec.to_string(unit="deg")
     return (
@@ -253,7 +254,7 @@ def get_source_markers(obsid, wcs, dbfile=None):
                 "name": str(row["name"]),
                 "catalog": str(row["catalog"]),
                 "symbol": symbol_for[str(row["catalog"])],
-                "simbad_url": _simbad_url(row["loc"]),
+                "simbad_url": simbad_url(row["loc"]),
             }
         )
 
@@ -362,7 +363,7 @@ def get_source_figure_data(
         mx = float(mx) - x0
         my = float(my) - y0
         if _inside(mx, my):
-            match = {"x": mx, "y": my, "simbad_url": _simbad_url(c_loc)}
+            match = {"x": mx, "y": my, "simbad_url": simbad_url(c_loc)}
 
     return {
         "image": cropped,

--- a/ska_trend/astromon/data.py
+++ b/ska_trend/astromon/data.py
@@ -1,0 +1,376 @@
+"""
+Data access for the astromon trending reports.
+
+This module wraps the ``astromon`` package data layer (cross-matches and the per-OBSID
+catalog/x-ray source tables) and prepares the cropped sky-view image used by the per-source
+report pages.
+
+The image and marker logic is a static-rendering port of the per-OBSID logic in the kadi-apps
+astromon flask blueprint (``kadi_apps/blueprints/astromon.py``).
+"""
+
+import functools
+import logging
+import warnings
+from pathlib import Path
+
+import numpy as np
+from astromon import db
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.table import Table
+from astropy.wcs import WCS, FITSFixedWarning
+from cxotime import CxoTime
+
+logger = logging.getLogger("astromon")
+
+__all__ = [
+    "get_matches",
+    "binned_offsets",
+    "get_obsid_image",
+    "get_source_markers",
+    "crop_box",
+    "get_source_figure_data",
+]
+
+# Plotly marker symbols cycled through for the vicinity catalog sources (one per catalog).
+CATALOG_SYMBOLS = [
+    "star-triangle-up",
+    "star-triangle-down",
+    "star-square",
+    "star-diamond",
+]
+
+# Science categories excluded by the celmon CAL/MTA selections (they confound source detection).
+CELMON_EXCLUDE_CATEGORIES = [
+    "SN, SNR, and Isolated NS",
+    "Solar System and Misc",
+    "Clusters of Galaxies",
+]
+
+# Cross-match selections. "all" is unfiltered; "cal" and "mta" reproduce the celmon
+# create_figures_cal / create_figures_mta selections (they differ only in the SNR threshold).
+SELECTIONS = {
+    "all": {},
+    "cal": {
+        "snr": 5,
+        "exclude_bad_targets": True,
+        "sim_z": 4,
+        "exclude_categories": CELMON_EXCLUDE_CATEGORIES,
+    },
+    "mta": {
+        "snr": 3,
+        "exclude_bad_targets": True,
+        "sim_z": 4,
+        "exclude_categories": CELMON_EXCLUDE_CATEGORIES,
+    },
+}
+
+
+def get_matches(selection="mta", dbfile=None):
+    """
+    Return a table of astrometric cross-matches, one row per (OBSID, x-ray source) pair.
+
+    Parameters
+    ----------
+    selection : str
+        One of "all", "cal", "mta" (see :data:`SELECTIONS`). "all" applies no filtering;
+        "cal"/"mta" reproduce the celmon selections. Default: "mta".
+    dbfile : str or Path, optional
+        Path to the astromon HDF5 db. If None, the astromon default is used
+        ($ASTROMON_FILE or $SKA/data/astromon/astromon.h5).
+
+    Returns
+    -------
+    astropy.table.Table
+    """
+    matches = db.get_cross_matches(dbfile=dbfile, **SELECTIONS[selection])
+    if selection != "all":
+        # celmon drops observations processed without a caldb version
+        matches = matches[matches["caldb_version"] != "0.0"]
+    matches["idx"] = np.arange(len(matches))
+    # date_obs is a string column; expose an ISO datetime usable as a plotly x-axis value.
+    matches["date_iso"] = CxoTime(matches["date_obs"]).isot
+    return matches
+
+
+def binned_offsets(matches, coord, bins_per_year=2):
+    """
+    Per-bin median and 1-sigma band of an offset column versus time.
+
+    Replicates the celmon ``binned_median``: time is binned ``bins_per_year`` bins per calendar
+    year; each bin reports the median and the 15.8 / 84.2 percentiles (the ±1-sigma band).
+
+    Parameters
+    ----------
+    matches : astropy.table.Table
+        Cross-match table (needs a CxoTime ``time`` column and the ``coord`` column).
+    coord : str
+        Offset column name ("dy" or "dz").
+    bins_per_year : int
+        Number of time bins per calendar year.
+
+    Returns
+    -------
+    dict with array values ``start``, ``stop`` (bin edges as fractional years) and ``median``,
+    ``sigma_minus``, ``sigma_plus`` (the offset statistics per bin). Empty arrays if no data.
+    """
+    if len(matches) == 0:
+        keys = ("start", "stop", "median", "sigma_minus", "sigma_plus")
+        return dict.fromkeys(keys, np.array([]))
+
+    years = np.array(matches["time"].frac_year)
+    ymin = np.floor(np.min(years / bins_per_year)) * bins_per_year
+    ymax = np.ceil(np.max(years / bins_per_year)) * bins_per_year
+    nbins = int((ymax - ymin) * bins_per_year)
+    bins = np.linspace(ymin, ymax, nbins + 1)
+
+    groups = Table(
+        [np.digitize(years, bins), np.asarray(matches[coord])], names=["bin", "val"]
+    ).group_by("bin")
+
+    def q(quantile):
+        return np.asarray(
+            groups["val"].groups.aggregate(functools.partial(np.quantile, q=quantile))
+        )
+
+    bin_idx = np.asarray(groups.groups.keys["bin"])
+    return {
+        "start": bins[bin_idx - 1],
+        "stop": bins[bin_idx],
+        "median": q(0.5),
+        "sigma_minus": q(0.158),
+        "sigma_plus": q(0.842),
+    }
+
+
+def _images_dir(obsid, archive_dir):
+    return (
+        Path(archive_dir) / f"obs{int(obsid) // 1000:02d}" / str(int(obsid)) / "images"
+    )
+
+
+def _find_flux_image(obsid, archive_dir):
+    subdir = _images_dir(obsid, archive_dir)
+    images = list(subdir.glob("*broad_flux.img")) + list(subdir.glob("*wide_flux.img"))
+    return images[0] if images else None
+
+
+def get_obsid_image(obsid, archive_dir):
+    """
+    Load the flux image for an OBSID and return (log-scaled image, WCS).
+
+    Parameters
+    ----------
+    obsid : int
+    archive_dir : str or Path
+        Astromon archive directory (e.g. $SKA/data/astromon/xray_observations).
+
+    Returns
+    -------
+    tuple(np.ndarray, astropy.wcs.WCS) or (None, None)
+        The log10-scaled image and its WCS, or (None, None) if no image is available.
+    """
+    filename = _find_flux_image(obsid, archive_dir)
+    if filename is None:
+        logger.info(
+            f"No flux image for OBSID {obsid} in {_images_dir(obsid, archive_dir)}"
+        )
+        return None, None
+
+    hdus = fits.open(filename)
+    # FITS data is typically big-endian; use a native-endian float array so the result
+    # can be JSON-serialized by plotly.
+    data = hdus[0].data
+    image = np.zeros(data.shape, dtype=np.float64)
+    positive = data > 0
+    if np.any(positive):
+        n_min = np.min(data[positive])
+        image[positive] = np.log10(data[positive])
+        image[~positive] = np.log10(n_min) - 1
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FITSFixedWarning)
+        wcs = WCS(hdus[0].header)
+    return image, wcs
+
+
+def _simbad_url(loc):
+    ra = loc.ra.to_string(unit="hour")
+    dec = loc.dec.to_string(unit="deg")
+    return (
+        "https://simbad.u-strasbg.fr/simbad/sim-coo?"
+        f"Coord={ra}%2B{dec}&CooFrame=ICRS&CooEpoch=2000&Radius=2&Radius.unit=arcsec"
+    )
+
+
+def get_source_markers(obsid, wcs, dbfile=None):
+    """
+    Build the marker layers (in pixel coordinates) for the per-OBSID sky view.
+
+    Parameters
+    ----------
+    obsid : int
+    wcs : astropy.wcs.WCS
+        WCS of the OBSID flux image (used to convert world -> pixel).
+    dbfile : str or Path, optional
+
+    Returns
+    -------
+    dict with keys:
+        ``xray`` : dict(x, y, id) for the detected x-ray sources
+        ``matches`` : list of dicts (matched catalog counterparts)
+        ``vicinity`` : list of dicts (rough catalog sources in the field), each carrying
+                       a ``symbol`` for plotting.
+    """
+    cat = db.get_table("astromon_cat_src", dbfile=dbfile)
+    xray = db.get_table("astromon_xray_src", dbfile=dbfile)
+    cat = cat[cat["obsid"] == obsid]
+    xray = xray[xray["obsid"] == obsid]
+
+    xray["loc"] = SkyCoord(xray["ra"] * u.deg, xray["dec"] * u.deg)
+    xray_x, xray_y = wcs.world_to_pixel(xray["loc"])
+    xray_markers = {
+        "x": np.atleast_1d(xray_x).tolist(),
+        "y": np.atleast_1d(xray_y).tolist(),
+        "id": xray["id"].tolist(),
+    }
+
+    cat["loc"] = SkyCoord(cat["ra"] * u.deg, cat["dec"] * u.deg)
+    cat_x, cat_y = wcs.world_to_pixel(cat["loc"])
+    catalogs = sorted(set(cat["catalog"].tolist()))
+    symbol_for = {
+        name: CATALOG_SYMBOLS[i % len(CATALOG_SYMBOLS)]
+        for i, name in enumerate(catalogs)
+    }
+    vicinity = []
+    for row, x, y in zip(cat, np.atleast_1d(cat_x), np.atleast_1d(cat_y), strict=True):
+        vicinity.append(
+            {
+                "id": row["id"],
+                "x": float(x),
+                "y": float(y),
+                "name": str(row["name"]),
+                "catalog": str(row["catalog"]),
+                "symbol": symbol_for[str(row["catalog"])],
+                "simbad_url": _simbad_url(row["loc"]),
+            }
+        )
+
+    return {"xray": xray_markers, "vicinity": vicinity}
+
+
+def crop_box(image, cx, cy, half_size):
+    """
+    Crop a square window of ``image`` centered on pixel (cx, cy).
+
+    Parameters
+    ----------
+    image : np.ndarray
+        2D image array (indexed [y, x]).
+    cx, cy : float
+        Center pixel coordinates (column, row).
+    half_size : int
+        Half the window size in pixels.
+
+    Returns
+    -------
+    tuple(np.ndarray, int, int)
+        The cropped image and the (x0, y0) pixel offset of its lower-left corner. Marker pixel
+        coordinates can be shifted into the cropped frame by subtracting (x0, y0).
+    """
+    ny, nx = image.shape
+    cxi = int(round(cx))
+    cyi = int(round(cy))
+    x0 = max(0, cxi - half_size)
+    x1 = min(nx, cxi + half_size + 1)
+    y0 = max(0, cyi - half_size)
+    y1 = min(ny, cyi + half_size + 1)
+    return image[y0:y1, x0:x1], x0, y0
+
+
+def get_source_figure_data(
+    obsid, x_loc, archive_dir, c_loc=None, dbfile=None, half_size=40
+):
+    """
+    Assemble everything needed to draw the cropped sky view for one source.
+
+    Parameters
+    ----------
+    obsid : int
+    x_loc : astropy.coordinates.SkyCoord
+        Sky position of the x-ray source (the crop is centered here).
+    archive_dir : str or Path
+    c_loc : astropy.coordinates.SkyCoord, optional
+        Sky position of the matched catalog counterpart (drawn as the highlighted match).
+    dbfile : str or Path, optional
+    half_size : int
+        Half the crop window size in pixels.
+
+    Returns
+    -------
+    dict or None
+        None if the OBSID has no flux image. Otherwise a dict with the cropped ``image``,
+        the crop offsets ``x0``/``y0``, the source center pixel (``cx``, ``cy``), the matched
+        counterpart pixel (``match``), and the marker layers (``xray``, ``vicinity``) with
+        pixel coordinates already shifted into the cropped frame.
+    """
+    image, wcs = get_obsid_image(obsid, archive_dir)
+    if image is None:
+        return None
+
+    cx, cy = wcs.world_to_pixel(x_loc)
+    cx = float(cx)
+    cy = float(cy)
+    cropped, x0, y0 = crop_box(image, cx, cy, half_size)
+
+    markers = get_source_markers(obsid, wcs, dbfile=dbfile)
+
+    ny, nx = cropped.shape
+
+    def _inside(x, y):
+        return 0 <= x < nx and 0 <= y < ny
+
+    # shift marker pixel coordinates into the cropped frame, keeping only those that
+    # actually fall inside the cropped region.
+    xray_in = [
+        (x - x0, y - y0, sid)
+        for x, y, sid in zip(
+            markers["xray"]["x"],
+            markers["xray"]["y"],
+            markers["xray"]["id"],
+            strict=True,
+        )
+        if _inside(x - x0, y - y0)
+    ]
+    xray = {
+        "x": [x for x, _, _ in xray_in],
+        "y": [y for _, y, _ in xray_in],
+        "id": [sid for _, _, sid in xray_in],
+    }
+
+    vicinity = []
+    for m in markers["vicinity"]:
+        m["x"] -= x0
+        m["y"] -= y0
+        if _inside(m["x"], m["y"]):
+            vicinity.append(m)
+
+    match = None
+    if c_loc is not None:
+        mx, my = wcs.world_to_pixel(c_loc)
+        mx = float(mx) - x0
+        my = float(my) - y0
+        if _inside(mx, my):
+            match = {"x": mx, "y": my, "simbad_url": _simbad_url(c_loc)}
+
+    return {
+        "image": cropped,
+        "x0": x0,
+        "y0": y0,
+        "cx": cx - x0,
+        "cy": cy - y0,
+        "match": match,
+        "xray": xray,
+        "vicinity": vicinity,
+    }

--- a/ska_trend/astromon/plotly.py
+++ b/ska_trend/astromon/plotly.py
@@ -1,0 +1,230 @@
+"""
+Plotly figures for the astromon trending reports.
+
+Two kinds of figures:
+
+- :func:`get_offsets_history_figure` -- the dY/dZ vs time timelines shown on the summary page.
+  Points carry ``customdata = [obsid, x_id]`` so the page javascript can open the matching
+  per-source report on click.
+- :func:`get_source_figure` -- the cropped sky view (flux image heatmap + catalog/x-ray markers)
+  that is the main element of each per-source page. This mirrors the react ``ObsidImage.js``
+  component, but cropped around the source.
+"""
+
+import plotly.graph_objects as go
+from cxotime import CxoTime
+
+from ska_trend.astromon import data
+
+__all__ = [
+    "get_offsets_history_figure",
+    "get_source_figure",
+]
+
+# axis labels and colors for each offset coordinate (matching celmon: dy blue, dz orange)
+COORD_INFO = {
+    "dy": {"title": "dY (arcsec)", "color": "#1f77b4"},
+    "dz": {"title": "dZ (arcsec)", "color": "#ff7f0e"},
+}
+
+
+def _year_to_iso(years):
+    """Convert an array of fractional years to ISO date strings for a plotly date axis."""
+    if len(years) == 0:
+        return []
+    return list(CxoTime(years, format="frac_year").isot)
+
+
+def _median_band_traces(matches, coord, color):
+    """
+    Build the binned-median line and ±1-sigma band traces (celmon q-history style).
+
+    The median is drawn as one horizontal segment per time bin (disconnected between bins);
+    the band is a single filled step polygon between the 15.8 and 84.2 percentiles.
+    """
+    binned = data.binned_offsets(matches, coord)
+    start_iso = _year_to_iso(binned["start"])
+    stop_iso = _year_to_iso(binned["stop"])
+    if not start_iso:
+        return []
+
+    # ±1-sigma band: upper boundary left->right, then lower boundary right->left, closed.
+    x_band, y_band = [], []
+    for s, e, hi in zip(start_iso, stop_iso, binned["sigma_plus"], strict=True):
+        x_band += [s, e]
+        y_band += [hi, hi]
+    for s, e, lo in zip(
+        reversed(start_iso),
+        reversed(stop_iso),
+        reversed(binned["sigma_minus"]),
+        strict=True,
+    ):
+        x_band += [e, s]
+        y_band += [lo, lo]
+    band = go.Scatter(
+        x=x_band,
+        y=y_band,
+        mode="lines",
+        line={"width": 0},
+        fill="toself",
+        fillcolor="rgba(255,127,14,0.25)" if coord == "dz" else "rgba(31,119,180,0.25)",
+        hoverinfo="skip",
+        name="±1σ",
+    )
+
+    # median: one horizontal segment per bin, broken by None so bins are not connected.
+    x_med, y_med = [], []
+    for s, e, med in zip(start_iso, stop_iso, binned["median"], strict=True):
+        x_med += [s, e, None]
+        y_med += [med, med, None]
+    median = go.Scatter(
+        x=x_med,
+        y=y_med,
+        mode="lines",
+        line={"color": color, "width": 3},
+        hoverinfo="skip",
+        name="median",
+    )
+
+    return [band, median]
+
+
+def get_offsets_history_figure(matches, coord):
+    """
+    Time series of an offset coordinate (``dy`` or ``dz``) versus time.
+
+    A binned-median line and ±1-sigma band are overlaid (as on the celmon q-history plot).
+
+    Parameters
+    ----------
+    matches : astropy.table.Table
+        Cross-match table (must have ``date_iso``, ``time``, ``obsid``, ``x_id`` and ``coord``).
+    coord : str
+        Either ``"dy"`` or ``"dz"``.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    info = COORD_INFO[coord]
+    # Use SVG Scatter (not Scattergl): WebGL traces in an initially-hidden tab pane never build
+    # their click layer, so plotly_click would not fire in non-default tabs. Point counts here
+    # (hundreds to a couple thousand) are well within SVG's comfort zone.
+    scatter = go.Scatter(
+        {
+            "x": list(matches["date_iso"]),
+            "y": list(matches[coord]),
+            "mode": "markers",
+            "name": coord,
+            "marker": {"size": 5, "color": "rgba(0,0,0,0.4)"},
+            "customdata": matches[["obsid", "x_id"]],
+            "hovertemplate": (
+                "OBSID: %{customdata[0]}<br>"
+                "x_id: %{customdata[1]}<br>"
+                f"{coord}: %{{y:.2f}}<extra></extra>"
+            ),
+        }
+    )
+    fig = go.Figure(data=[scatter, *_median_band_traces(matches, coord, info["color"])])
+    fig.update_layout({"showlegend": False, "template": "simple_white"})
+    # match celmon's initial vertical range (points outside are still reachable by zooming out)
+    fig.update_yaxes({"title": info["title"], "range": [-1.1, 1.1]})
+    fig.update_xaxes({"title": "Date"})
+    return fig
+
+
+def get_source_figure(fig_data):
+    """
+    Cropped sky view for a single source.
+
+    Parameters
+    ----------
+    fig_data : dict
+        Output of :func:`ska_trend.astromon.data.get_source_figure_data`.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    fig = go.Figure()
+
+    # the cropped flux image
+    fig.add_trace(
+        go.Heatmap(
+            z=fig_data["image"],
+            colorscale="Greys",
+            showscale=False,
+            hoverinfo="skip",
+        )
+    )
+
+    # vicinity catalog sources (blue, one symbol per catalog)
+    by_catalog = {}
+    for m in fig_data["vicinity"]:
+        by_catalog.setdefault(m["catalog"], []).append(m)
+    for catalog, members in by_catalog.items():
+        fig.add_trace(
+            go.Scatter(
+                x=[m["x"] for m in members],
+                y=[m["y"] for m in members],
+                mode="markers",
+                name=catalog,
+                text=[f"{m['catalog']}<br>{m['name']}" for m in members],
+                customdata=[m["simbad_url"] for m in members],
+                hovertemplate="%{text}<br>(click to open SIMBAD)<extra></extra>",
+                marker={
+                    "symbol": members[0]["symbol"],
+                    "size": 10,
+                    "color": "rgba(0,0,0,0)",
+                    "line": {"color": "dodgerblue", "width": 2},
+                },
+            )
+        )
+
+    # the matched catalog counterpart for this source (red)
+    if fig_data.get("match") is not None:
+        fig.add_trace(
+            go.Scatter(
+                x=[fig_data["match"]["x"]],
+                y=[fig_data["match"]["y"]],
+                mode="markers",
+                name="X-match",
+                customdata=[fig_data["match"]["simbad_url"]],
+                hovertemplate="matched counterpart<br>(click to open SIMBAD)<extra></extra>",
+                marker={
+                    "symbol": "circle-dot",
+                    "size": 20,
+                    "color": "rgba(0,0,0,0)",
+                    "line": {"color": "rgb(204,51,0)", "width": 2},
+                },
+            )
+        )
+
+    # the x-ray source detections (orange)
+    xray = fig_data["xray"]
+    fig.add_trace(
+        go.Scatter(
+            x=xray["x"],
+            y=xray["y"],
+            mode="markers",
+            name="X-Ray Source",
+            hoverinfo="skip",
+            marker={
+                "symbol": "circle",
+                "size": 8,
+                "color": "rgba(0,0,0,0)",
+                "line": {"color": "rgb(204,102,0)", "width": 2},
+            },
+        )
+    )
+
+    fig.update_layout(
+        {
+            "template": "simple_white",
+            "legend": {"x": 1, "xanchor": "right", "y": 1},
+            "showlegend": True,
+        }
+    )
+    fig.update_yaxes({"scaleanchor": "x", "showgrid": False, "showticklabels": False})
+    fig.update_xaxes({"showgrid": False, "showticklabels": False})
+    return fig

--- a/ska_trend/astromon/reports.py
+++ b/ska_trend/astromon/reports.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import jinja2
 from astropy import units as u
+from mica.archive.cda import get_proposal_abstract
 from tqdm import tqdm
 
 from ska_trend.astromon import data
@@ -171,10 +172,21 @@ def write_source_html_report(row, filename, archive_dir, dbfile=None, overwrite=
         # RA/Dec of the matched catalog source, for the exclude command
         "ra": float(row["c_ra"]),
         "dec": float(row["c_dec"]),
+        # SIMBAD coord-search link for the matched counterpart
+        "simbad_url": data.simbad_url(row["c_loc"]),
     }
 
+    try:
+        abstract = get_proposal_abstract(obsid)
+    except Exception as exc:
+        if str(exc).startswith("got error 404") or str(exc).startswith("got error 503"):
+            abstract = ""
+        else:
+            raise
+    ocat = {"abstract": abstract}
+
     template = JINJA_ENV.get_template("source_report.html")
-    page = template.render(source=source, source_figure=source_figure)
+    page = template.render(source=source, source_figure=source_figure, ocat=ocat)
 
     if not filename.parent.exists():
         filename.parent.mkdir(exist_ok=True, parents=True)

--- a/ska_trend/astromon/reports.py
+++ b/ska_trend/astromon/reports.py
@@ -1,0 +1,252 @@
+"""
+Top-level functions to generate HTML reports for astromon (astrometry) trending.
+
+The structure mirrors ``ska_trend.periscope_drift.reports``: a summary page (``index.html``)
+with 90-day / 1-year / 5-year tabs, and one per-source page per (OBSID, x-ray source).
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import jinja2
+from astropy import units as u
+from tqdm import tqdm
+
+from ska_trend.astromon import data
+from ska_trend.astromon import plotly as plots
+
+logger = logging.getLogger("astromon")
+
+__all__ = [
+    "write_report",
+    "write_html_report",
+    "write_source_html_report",
+]
+
+
+JINJA_ENV = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(Path(__file__).parent / "templates" / "astromon")
+)
+
+# plotly .to_html kwargs shared by all figures
+PLOTLY_KWARGS = {
+    "config": {"responsive": True},
+    "full_html": False,
+    "include_plotlyjs": "cdn",
+}
+
+
+def get_data_for_interval(start, stop, matches, idx=0):
+    """
+    Build the per-tab data dict (the two offset timelines) for a time interval.
+    """
+    sel = (matches["time"] >= start) & (matches["time"] < stop)
+    interval = matches[sel]
+
+    return {
+        "start": start.date[:8],
+        "stop": stop.date[:8],
+        "start_iso": start.iso[:10],
+        "stop_iso": stop.iso[:10],
+        "n": len(interval),
+        "dz_history": plots.get_offsets_history_figure(interval, "dz").to_html(
+            div_id=f"dz_history_{idx}", **PLOTLY_KWARGS
+        ),
+        "dy_history": plots.get_offsets_history_figure(interval, "dy").to_html(
+            div_id=f"dy_history_{idx}", **PLOTLY_KWARGS
+        ),
+    }
+
+
+def _source_file(outdir, obsid, x_id):
+    return (
+        Path(outdir)
+        / "sources"
+        / f"{float(obsid) // 1e3:02.0f}"
+        / f"{obsid}"
+        / str(x_id)
+        / "index.html"
+    )
+
+
+def write_html_report(
+    time_ranges,
+    outdir,
+    matches,
+    archive_dir,
+    dbfile=None,
+    overwrite=False,
+    show_progress=False,
+):
+    """
+    Render and write the html pages (one summary page and one per source).
+    """
+    outdir = Path(outdir)
+    outdir.mkdir(exist_ok=True, parents=True)
+
+    # JS format string giving the relative path from the summary page to a source report.
+    # Interpolated in the plotly onClick handler from customdata = [obsid, x_id].
+    # Must match the layout produced by _source_file / write_source_html_report.
+    source_report_path = (
+        "`sources/${String(Math.floor(Number(obsid) / 1e3)).padStart(2, '0')}"
+        "/${obsid}/${x_id}/index.html`"
+    )
+    context = {"source_report_path": source_report_path}
+
+    # per-source pages
+    if show_progress:
+        print("Writing source reports...")
+    rows = tqdm(matches) if show_progress else matches
+    source_files = []
+    for row in rows:
+        src_file = _source_file(outdir, row["obsid"], row["x_id"])
+        write_source_html_report(
+            row, src_file.as_posix(), archive_dir, dbfile=dbfile, overwrite=overwrite
+        )
+        source_files.append(src_file.relative_to(outdir).as_posix())
+
+    matches["filename"] = source_files
+
+    (outdir / "sources").mkdir(exist_ok=True, parents=True)
+    with open(outdir / "sources" / "all.json", "w") as fh:
+        json.dump(
+            matches[["obsid", "x_id", "filename"]].as_array().tolist(), fh, indent=2
+        )
+
+    # summary page
+    range_data = [
+        get_data_for_interval(tr["start"], tr["stop"], matches=matches, idx=idx)
+        for idx, tr in enumerate(time_ranges)
+    ]
+    for rd, tr in zip(range_data, time_ranges, strict=True):
+        rd["title"] = tr["title"]
+
+    template = JINJA_ENV.get_template("index.html")
+    page = template.render(time_ranges=range_data, context=context)
+    with open(outdir / "index.html", "w") as fh:
+        fh.write(page)
+
+
+def write_source_html_report(row, filename, archive_dir, dbfile=None, overwrite=False):
+    """
+    Render and write a report for a single source (one x-ray source in one OBSID).
+    """
+    filename = Path(filename)
+    if filename.exists() and not overwrite:
+        return
+
+    obsid = int(row["obsid"])
+    x_id = int(row["x_id"])
+
+    fig_data = data.get_source_figure_data(
+        obsid,
+        row["x_loc"],
+        archive_dir,
+        c_loc=row["c_loc"],
+        dbfile=dbfile,
+    )
+    source_figure = None
+    if fig_data is not None:
+        fig = plots.get_source_figure(fig_data)
+        fig.update_layout({"margin": {"l": 0, "r": 0, "b": 0, "t": 0}})
+        source_figure = fig.to_html(div_id="source_figure", **PLOTLY_KWARGS)
+
+    source = {
+        "obsid": obsid,
+        "x_id": x_id,
+        "c_id": row["c_id"],
+        "target": row["target"],
+        "catalog": row["catalog"],
+        "name": row["name"],
+        "category": row["category"],
+        "detector": row["detector"],
+        "grating": row["grating"],
+        "dy": float(row["dy"]),
+        "dz": float(row["dz"]),
+        "dr": float(row["dr"]),
+        "snr": float(row["snr"]),
+        "r_angle": float(row["r_angle"]),
+        "date_obs": str(row["date_obs"]),
+        # RA/Dec of the matched catalog source, for the exclude command
+        "ra": float(row["c_ra"]),
+        "dec": float(row["c_dec"]),
+    }
+
+    template = JINJA_ENV.get_template("source_report.html")
+    page = template.render(source=source, source_figure=source_figure)
+
+    if not filename.parent.exists():
+        filename.parent.mkdir(exist_ok=True, parents=True)
+    with open(filename, "w") as fh:
+        fh.write(page)
+
+
+def write_report(
+    start,
+    stop,
+    output_dir,
+    archive_dir,
+    dbfile=None,
+    matches=None,
+    selection="mta",
+    overwrite=False,
+    show_progress=False,
+):
+    """
+    Write reports for a given time interval. Calls all the write_* functions.
+
+    Parameters
+    ----------
+    start : CxoTime
+        Start of the report interval (only sources with ``time >= start`` are included).
+    stop : CxoTime
+        Stop of the report interval.
+    output_dir : str or Path
+    archive_dir : str or Path
+        Astromon archive directory (for the flux images), e.g.
+        $SKA/data/astromon/xray_observations.
+    dbfile : str or Path, optional
+        Astromon HDF5 db. If None, the astromon default is used.
+    matches : astropy.table.Table, optional
+        Pre-loaded cross-match table. If None, cross-matches are loaded using ``selection``.
+    selection : str
+        Cross-match selection ("all", "cal", "mta") used when ``matches`` is None. Default: "mta".
+    """
+    # 5-year tab, plus an "all" tab covering the full report interval when it goes back further
+    five_years = stop - 5 * 365 * u.day
+    time_ranges = [
+        {"start": five_years, "stop": stop, "title": "5 years"},
+    ]
+    if start < five_years:
+        time_ranges.append({"start": start, "stop": stop, "title": "all"})
+
+    if matches is None:
+        matches = data.get_matches(selection=selection, dbfile=dbfile)
+
+    # only sources within the full report interval
+    report_matches = matches[(matches["time"] >= start) & (matches["time"] < stop)]
+    # sort by time so per-source next/prev navigation is chronological
+    report_matches.sort("time")
+
+    write_html_report(
+        time_ranges,
+        output_dir,
+        report_matches,
+        archive_dir,
+        dbfile=dbfile,
+        overwrite=overwrite,
+        show_progress=show_progress,
+    )
+
+    with open(Path(output_dir) / "args.json", "w") as fh:
+        args = {
+            "start": start,
+            "stop": stop,
+            "output_dir": str(output_dir),
+            "archive_dir": str(archive_dir),
+            "dbfile": str(dbfile),
+            "selection": selection,
+            "n_sources": len(report_matches),
+        }
+        json.dump(args, fh, indent=2, default=str)

--- a/ska_trend/astromon/scripts/astromon_reports.py
+++ b/ska_trend/astromon/scripts/astromon_reports.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+import ska_helpers
+from cxotime import CxoTime
+
+from ska_trend.astromon import reports
+from ska_trend.time_utils import parse_time_arg
+
+logger = logging.getLogger("astromon")
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        default=Path(os.environ["SKA"]) / "www" / "ASPECT" / "astromon",
+        type=Path,
+        help="Report output directory. Default: $SKA/www/ASPECT/astromon",
+    )
+    parser.add_argument(
+        "--start-report",
+        default="stop-5yr",
+        help="Start of report interval (e.g. stop-5yr or a date). Default: stop-5yr",
+    )
+    parser.add_argument("--stop", default=None, help="Stop time. Default: NOW")
+    parser.add_argument(
+        "--matches",
+        choices=["all", "cal", "mta"],
+        default="mta",
+        help="Cross-match selection: all (unfiltered), cal, or mta. Default: mta",
+    )
+    parser.add_argument(
+        "--astromon-archive-dir",
+        default=Path(os.environ["SKA"]) / "data" / "astromon" / "xray_observations",
+        type=Path,
+        help="Astromon archive directory (flux images). "
+        "Default: $SKA/data/astromon/xray_observations",
+    )
+    parser.add_argument(
+        "--dbfile",
+        default=None,
+        type=Path,
+        help="Astromon HDF5 db file. Default: astromon default "
+        "($ASTROMON_FILE or $SKA/data/astromon/astromon.h5)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        type=str.upper,
+        help="Verbosity. Default: INFO.",
+    )
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        type=Path,
+        help="Log file. If not specified, log to stdout.",
+    )
+    parser.add_argument(
+        "--show-progress",
+        action="store_true",
+        help="Show progress bar",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing per-source pages",
+    )
+    return parser
+
+
+def main():
+    args = get_parser().parse_args()
+
+    log_args = {"level": args.log_level, "format": "%(message)s"}
+    log_args.update(
+        {"stream": sys.stdout} if args.log_file is None else {"filename": args.log_file}
+    )
+    logger = ska_helpers.logging.basic_logger("astromon", **log_args)
+
+    now = CxoTime()
+    logger.info("---------- astromon reports update at %s ----------" % (now.iso))
+
+    stop = now if args.stop is None else CxoTime(args.stop)
+    start_report = parse_time_arg(args.start_report, stop)
+
+    reports.write_report(
+        start=start_report,
+        stop=stop,
+        output_dir=args.output,
+        archive_dir=args.astromon_archive_dir,
+        dbfile=args.dbfile,
+        selection=args.matches,
+        overwrite=args.overwrite,
+        show_progress=args.show_progress,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ska_trend/astromon/scripts/astromon_reports.py
+++ b/ska_trend/astromon/scripts/astromon_reports.py
@@ -88,7 +88,7 @@ def main():
     logger.info("---------- astromon reports update at %s ----------" % (now.iso))
 
     stop = now if args.stop is None else CxoTime(args.stop)
-    start_report = parse_time_arg(args.start_report, stop)
+    start_report = parse_time_arg(args.start_report, stop=stop)
 
     reports.write_report(
         start=start_report,

--- a/ska_trend/astromon/task_schedule.cfg
+++ b/ska_trend/astromon/task_schedule.cfg
@@ -1,0 +1,48 @@
+# Configuration file for task_schedule.pl to run astromon jobs
+
+subject           Astromon Reports
+timeout           3600               # Default tool timeout
+heartbeat_timeout 30000             # Maximum age of heartbeat file (seconds)
+iterations        1                 # Run once then shut down task_schedule
+print_error       1                 # Print full log of errors
+disable_alerts    0                 # Don't disable alerts since this jobs runs just once/day
+loud              0                 # Run loudly or quietly (production mode)
+
+# Data files and directories.  The *_dir vars can have $ENV{} vars which
+# get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
+
+data_dir     $ENV{SKA_DATA}/astromon       # Data file directory
+log_dir      $ENV{SKA_DATA}/astromon/logs  # Log file directory
+master_log   master.log             # Composite master log (created in log_dir)
+
+# Email addresses that receive an alert if there was a severe error in
+# running jobs (i.e. couldn't start jobs or couldn't open log file).
+# Processing errors *within* the jobs are caught with watch_cron_logs
+
+#notify       aca@head.cfa.harvard.edu
+alert        javier.gonzalez@cfa.harvard.edu
+
+# Define task parameters
+#  cron: Job repetition specification ala crontab
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
+#        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#  log: Name of log.  Can have $ENV{} vars which get interpolated.
+#        If log is set to '' then no log file will be created
+#        If log is not defined it is set to <task_name>.log.
+#        If log_dir is defined then log_dir is prepended to non-absolute log names.
+#  timeout: Maximum time (seconds) for job before timing out
+
+<task astromon_reports>
+      cron       * * * * *
+      check_cron * * * * *
+      exec 1: ska_trend_astromon --log-level debug
+      <check>
+        <error>
+          #    File           Expression
+          #  ----------      ---------------------------
+             *     Use of uninitialized value
+             *     error
+             *     fatal
+        </error>
+      </check>
+</task>

--- a/ska_trend/astromon/templates/astromon/index.html
+++ b/ska_trend/astromon/templates/astromon/index.html
@@ -1,0 +1,126 @@
+<html>
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+
+    <script id="MathJax" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+	</script>
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+				rel="stylesheet"
+				integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+				crossorigin="anonymous">
+
+	<style>
+		h1 {
+			color: #990000;
+		}
+
+		h2 {
+			color: #990000;
+		}
+
+		/* Keep inactive tab panes in the layout at full width (clipped to zero height) instead
+		   of display:none, so Plotly always draws its figures at the correct size and they are
+		   immediately interactive. Avoids the hidden-render resize/click problems. */
+		.tab-content > .tab-pane {
+			display: block !important;
+			height: 0;
+			overflow: hidden;
+		}
+		.tab-content > .tab-pane.active {
+			height: auto;
+			overflow: visible;
+		}
+	</style>
+  <title>Astromon Trending Report</title>
+</head>
+
+<body>
+	<div class="container-md">
+		<!--#include virtual="/incl/header.html"-->
+	</div>
+
+	<div class="container-md">
+		<h2> Astromon Trending Report </h2>
+
+		<p>
+			Angular offset between Chandra X-ray source positions and their catalog
+			counterparts, versus time. Click a point to open the per-source report.
+		</p>
+
+		<ul class="nav nav-tabs" role="tablist">
+			{% for time_range in time_ranges %}
+			<li class="nav-item" role="presentation">
+			<a class="nav-link{% if loop.index == 1 %} active{% endif %}" id="tab-{{ loop.index }}" data-bs-toggle="tab" href="#simple-tabpanel-{{ loop.index }}" role="tab" aria-controls="simple-tabpanel-{{ loop.index }}" aria-selected={% if loop.index == 1 %}"true"{% else %}"false"{% endif %}>{{ time_range.title }}</a>
+			</li>
+			{% endfor %}
+		</ul>
+		<div class="tab-content pt-5" id="tab-content">
+			{% for time_range in time_ranges %}
+			<div class="tab-pane{% if loop.index == 1 %} active{% endif %}" id="simple-tabpanel-{{ loop.index }}" role="tabpanel" aria-labelledby="tab-{{ loop.index }}">
+				<table class="table">
+					<tbody>
+						<tr>
+							<th>Start</th> <td>{{ time_range.start }} ({{ time_range.start_iso }})</td>
+						</tr>
+						<tr>
+							<th>Stop</th> <td>{{ time_range.stop }} ({{ time_range.stop_iso }})</td>
+						</tr>
+						<tr>
+							<th>Sources</th> <td>{{ time_range.n }}</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<h3> dY </h3>
+				<div class="ratio" style="--bs-aspect-ratio: 40%;">
+				{{time_range.dy_history}}
+				</div>
+
+				<h3> dZ </h3>
+				<div class="ratio" style="--bs-aspect-ratio: 40%;">
+				{{time_range.dz_history}}
+				</div>
+
+			</div>
+			{% endfor %}
+		</div>
+	</div>
+
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+    crossorigin="anonymous">
+  </script>
+
+  {% for time_range in time_ranges %}
+  {% set tr_idx = loop.index0 %}
+  {% for fig in ['dz_history', 'dy_history'] %}
+  <script>
+	// the figure ID is set in the to_html method of the plotly figure using `div_id=...`
+	var myPlot = document.getElementById('{{ fig }}_{{ tr_idx }}');
+
+	myPlot.on('plotly_click', function(data) {
+		// requires a clicked marker whose customdata is [obsid, x_id]; fails silently otherwise.
+		// The resulting URL must agree with the file/directory structure.
+		if (
+			!data.points
+			|| !data.points[0]
+			|| !data.points[0].customdata
+			|| data.points[0].customdata.length < 2
+		) {
+			return;
+		}
+		const obsid = data.points[0].customdata[0];
+		const x_id = data.points[0].customdata[1];
+		const path = {{ context.source_report_path }};
+		console.log(`opening path: ${path} for obsid: ${obsid}, x_id: ${x_id}`);
+		window.open(path, '_blank');
+	});
+  </script>
+  {% endfor %}
+  {% endfor %}
+
+
+</body>
+</html>

--- a/ska_trend/astromon/templates/astromon/source_report.html
+++ b/ska_trend/astromon/templates/astromon/source_report.html
@@ -74,7 +74,7 @@
               <th scope="row"> Catalog </th> <td>{{ source.catalog }} </td>
             </tr>
             <tr>
-              <th scope="row"> Counterpart </th> <td>{{ source.name }} (c_id {{ source.c_id }}) </td>
+              <th scope="row"> Counterpart </th> <td><a href="{{ source.simbad_url }}" target="_blank" rel="noopener">{{ source.name }}</a> (c_id {{ source.c_id }}) </td>
             </tr>
             <tr>
               <th scope="row"> dY (arcsec) </th> <td>{{ '{:.2f}'.format(source.dy) }} </td>
@@ -110,6 +110,22 @@
             <p> <div id="astromon_command"> <pre>
               astromon-excluded-region add --obsid {{ source.obsid }} --ra {{ source.ra }} --dec {{ source.dec }} --radius 10 --comment "Excluded after inspection";
             </pre></div> </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion" id="accordionOcat">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingOcat">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOcat" aria-expanded="true" aria-controls="collapseOcat">
+            OCAT Information
+          </button>
+        </h2>
+        <div id="collapseOcat" class="accordion-collapse collapse" aria-labelledby="headingOcat" data-bs-parent="#accordionOcat">
+          <div class="accordion-body">
+            <h3> {{ ocat.abstract.proposal_title }}</h3>
+            <p> {{ ocat.abstract.abstract }}</p>
           </div>
         </div>
       </div>

--- a/ska_trend/astromon/templates/astromon/source_report.html
+++ b/ska_trend/astromon/templates/astromon/source_report.html
@@ -1,0 +1,276 @@
+<html>
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+
+    <script id="MathJax" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+	</script>
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+				rel="stylesheet"
+				integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+				crossorigin="anonymous">
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css"
+    rel="stylesheet">
+
+	<style>
+		h1 {
+			color: #990000;
+		}
+
+		h2 {
+			color: #990000;
+		}
+	</style>
+  <title>Astromon Source Report</title>
+</head>
+
+<body data-observation="{{ source.obsid }}" data-source-id="{{ source.x_id }}" root-dir="../../../..">
+
+  <div class="container-md">
+
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand me-auto" href="../../../..">Astromon</a>
+      <div class="navbar-nav">
+        <a class="nav-item nav-link" href="#previous"><i class="bi bi-arrow-left"></i> prev</a>
+        <a class="nav-item nav-link" href="#next">next <i class="bi bi-arrow-right"></i> </a>
+      </div>
+    </nav>
+
+    <h2> OBSID {{ source.obsid }}, source {{ source.x_id }} </h2>
+
+    <div class="container">
+      <div class="row">
+        <div class="col-6">
+          <div>
+            {% if source_figure %}
+            {{source_figure}}
+            {% else %}
+            <div class="alert alert-warning"> No flux image available for this OBSID. </div>
+            {% endif %}
+          </div>
+        </div>
+        <div class="col-6">
+          <table class="table table-sm">
+            <tr>
+              <th scope="row"> OBSID </th> <td>{{ source.obsid }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> Date </th> <td>{{ source.date_obs }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> x_id </th> <td>{{ source.x_id }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> Target </th> <td>{{ source.target }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> Category </th> <td>{{ source.category }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> Detector / Grating </th> <td>{{ source.detector }} / {{ source.grating }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> Catalog </th> <td>{{ source.catalog }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> Counterpart </th> <td>{{ source.name }} (c_id {{ source.c_id }}) </td>
+            </tr>
+            <tr>
+              <th scope="row"> dY (arcsec) </th> <td>{{ '{:.2f}'.format(source.dy) }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> dZ (arcsec) </th> <td>{{ '{:.2f}'.format(source.dz) }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> dR (arcsec) </th> <td>{{ '{:.2f}'.format(source.dr) }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> SNR </th> <td>{{ '{:.1f}'.format(source.snr) }} </td>
+            </tr>
+            <tr>
+              <th scope="row"> off-axis angle (arcmin) </th> <td>{{ '{:.2f}'.format(source.r_angle) }} </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion" id="accordionExclude">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingExclude">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExclude" aria-expanded="true" aria-controls="collapseExclude">
+            Exclude this source
+          </button>
+        </h2>
+        <div id="collapseExclude" class="accordion-collapse collapse" aria-labelledby="headingExclude" data-bs-parent="#accordionExclude">
+          <div class="accordion-body">
+            <p> Login as aca and execute the following command(s). If this region should be excluded for all OBSIDs, remove the --obsid flag. Feel free to modify the comment. </p>
+            <p> to exclude from astromon: </p>
+            <p> <div id="astromon_command"> <pre>
+              astromon-excluded-region add --obsid {{ source.obsid }} --ra {{ source.ra }} --dec {{ source.dec }} --radius 10 --comment "Excluded after inspection";
+            </pre></div> </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+    crossorigin="anonymous">
+  </script>
+
+  <script>
+    const element = document.getElementById('astromon_command');
+    element.addEventListener('click', () => {
+      const htmlContent = element.childNodes[1].innerHTML
+      navigator.clipboard.writeText(htmlContent);
+    });
+  </script>
+
+  <script>
+    // Clicking a catalog marker (vicinity source or matched counterpart) opens its SIMBAD page.
+    // Only those traces carry a customdata URL; clicks on the image or x-ray markers are ignored.
+    const sourceFigure = document.getElementById('source_figure');
+    if (sourceFigure) {
+      sourceFigure.on('plotly_click', (data) => {
+        const point = data.points && data.points[0];
+        if (point && point.customdata) {
+          window.open(point.customdata, '_blank');
+        }
+      });
+    }
+  </script>
+
+</body>
+
+<script>
+
+  async function fetchObservations() {
+    // this is the key used in the URL parameters (?observations=...)
+    const urlKey = 'observations';
+    const storageKey = 'observations';
+    const root_dir = document.body.getAttribute('root-dir');
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const obs_list = urlParams.has(urlKey)? urlParams.get(urlKey): "all";
+    const url = `${root_dir}/sources/${obs_list}.json`
+    console.log(`Will fetch ${urlKey} list from url params: ${url}`);
+
+    const response = await fetch(url, { method: 'HEAD' });
+    if ( !response.ok ) {
+      console.log(`Failed fetching ${url}. Status: ${response.status}`);
+      return [[], -1];
+    }
+
+    const storedETag = sessionStorage.getItem(`${storageKey}_etag`);
+    const currentETag = response.headers.get('etag');
+    const outdated = (storedETag !== currentETag);
+
+    var entries = null;
+    const json_str = sessionStorage.getItem(storageKey);
+    if (json_str && !outdated) {
+      entries = JSON.parse(json_str);
+    }
+    else {
+      sessionStorage.setItem(`${storageKey}_etag`, currentETag);
+      const response = await fetch(url);
+      entries = await response.json();
+      sessionStorage.setItem(storageKey, JSON.stringify(entries));
+    }
+
+    const currentEntry = document.body.getAttribute('data-observation');
+    const currentSourceId = document.body.getAttribute('data-source-id');
+    const currentIndex = entries.findIndex(
+      ([obs, src_id, url]) => (
+        obs.toString() === currentEntry.toString()
+        && src_id.toString() === currentSourceId.toString()
+      )
+    );
+
+    _disableButtons_(entries, currentIndex)
+
+    return [entries, currentIndex];
+  }
+
+  function goToObservation(targetURL) {
+    const urlKey = 'observations';
+    const root_dir = document.body.getAttribute('root-dir');
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has(urlKey)) {
+      const obs_list = urlParams.get(urlKey);
+      targetURL = `${targetURL}?${urlKey}=${obs_list}`;
+    }
+    window.location.href = `${root_dir}/${targetURL}`;
+  }
+
+  async function previous() {
+    const [entries, currentIndex] = await fetchObservations();
+    targetIndex = currentIndex - 1;
+    if (currentIndex < 0 || currentIndex > entries.length - 1) {
+      alert("This entry is not in the list. Cannot navigate to previous.");
+    }
+    else if (targetIndex < 0) {
+      alert('No more entries in this direction.');
+    }
+    else {
+      goToObservation(entries[targetIndex][2]);
+    }
+  }
+
+  async function next() {
+    const [entries, currentIndex] = await fetchObservations();
+    targetIndex = currentIndex + 1;
+    if (currentIndex < 0 || currentIndex > entries.length - 1) {
+      alert("This entry is not in the list. Cannot navigate to next.");
+    }
+    else if (targetIndex > entries.length - 1) {
+      alert("No more entries in this direction.");
+    }
+    else {
+      goToObservation(entries[targetIndex][2]);
+    }
+  }
+
+  async function disableButtons() {
+    const [entries, currentIndex] = await fetchObservations();
+    _disableButtons_(entries, currentIndex);
+  }
+
+  function _disableButtons_(entries, currentIndex) {
+    if (currentIndex <= 0) {
+      document.querySelector('a[href="#previous"]').classList.add('disabled');
+    }
+    else {
+      document.querySelector('a[href="#previous"]').classList.remove('disabled');
+    }
+    if (currentIndex >= entries.length - 1 || currentIndex === -1) {
+      document.querySelector('a[href="#next"]').classList.add('disabled');
+    }
+    else {
+      document.querySelector('a[href="#next"]').classList.remove('disabled');
+    }
+  }
+</script>
+
+<script>
+document.querySelector('a[href="#next"]').addEventListener('click', (e) => {
+    e.preventDefault();
+    next();
+});
+
+document.querySelector('a[href="#previous"]').addEventListener('click', (e) => {
+    e.preventDefault();
+    previous();
+});
+</script>
+
+<script>
+  disableButtons();
+</script>
+
+</html>

--- a/ska_trend/astromon/tests/test_astromon.py
+++ b/ska_trend/astromon/tests/test_astromon.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from ska_trend.astromon import data
+
+
+def test_crop_box_interior():
+    image = np.arange(100).reshape(10, 10)
+    # crop a 3x3 window (half_size=1) centered on pixel (4, 5) -> column 4, row 5
+    cropped, x0, y0 = data.crop_box(image, 4, 5, 1)
+    assert (x0, y0) == (3, 4)
+    assert cropped.shape == (3, 3)
+    # the center pixel of the crop is image[5, 4]
+    assert cropped[1, 1] == image[5, 4]
+
+
+def test_crop_box_edge_is_clipped():
+    image = np.arange(100).reshape(10, 10)
+    # near the corner the window is clipped to the image bounds (no negative indices)
+    cropped, x0, y0 = data.crop_box(image, 0, 0, 3)
+    assert (x0, y0) == (0, 0)
+    assert cropped.shape == (4, 4)
+    assert cropped[0, 0] == image[0, 0]


### PR DESCRIPTION
## Description

**Add an `astromon` trending dashboard**

Adds a new `ska_trend.astromon` submodule that generates a static-HTML absolute astrometry (astromon) trending dashboard, mirroring the `periscope_drift` infrastructure.

- **Summary page**: a "5 years" tab (plus an "all" tab when the report goes back further) with two Plotly timelines — dY and dZ offset vs time — overlaid with a binned-median line and ±1σ band, celmon-style. Clicking a point opens that source's report.
- **Match selection**: `--matches {all,cal,mta}` (default `mta`), reproducing the celmon CAL/MTA selections so the timelines match the celmon MTA page.
- **Per-source pages** (one X-ray source per OBSID): cropped flux-image sky view with x-ray / matched / vicinity catalog markers, a metadata table, SIMBAD links (marker click and counterpart row), an OCAT/proposal info accordion, the `astromon-excluded-region` command, and prev/next navigation.
- Console script `ska_trend_astromon`, `task_schedule.cfg`, and unit tests.

Built on the `time-utils` branch (uses `time_utils.parse_time_arg`); merge that first.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
